### PR TITLE
Add show All button | Fixes #61

### DIFF
--- a/monitor/admin.py
+++ b/monitor/admin.py
@@ -52,6 +52,7 @@ class ArchivedObservationsAdmin(admin.ModelAdmin):
 
 
 class SitesAdmin(admin.ModelAdmin):
+    list_max_show_all = 1000
     list_display = (
         'site_name',
         'user',

--- a/monitor/admin.py
+++ b/monitor/admin.py
@@ -51,7 +51,14 @@ class ArchivedObservationsAdmin(admin.ModelAdmin):
     list_filter = ('flag',)
 
 
-admin.site.register(Sites)
+class SitesAdmin(admin.ModelAdmin):
+    list_display = (
+        'site_name',
+        'user',
+        'river_name',
+    )
+
+admin.site.register(Sites, SitesAdmin)
 admin.site.register(Observations, ObservationsAdmin)
 admin.site.register(ArchivedSites)
 admin.site.register(ArchivedObservations, ArchivedObservationsAdmin)


### PR DESCRIPTION
Hi @gubuntu do you mean like this?. When the button `show all` clicked the data will showed all. 
I set the maximum show all is 1000 data. Issue #61 

![screen shot 2015-10-27 at 4 41 32 pm](https://cloud.githubusercontent.com/assets/2235894/10754483/6d885c52-7cca-11e5-90ed-d332e51dae30.png)

if yes I'll merge it. 

thanks 
