### PR TITLE
Try to add marquee scroll banner on index page

### DIFF
--- a/minisass/static/css/base.css
+++ b/minisass/static/css/base.css
@@ -143,7 +143,7 @@ div.recent-observations {
 }
 .recent-observations h2 a:visited,
 .recent-observations h2 a:active,
-.recent-observations h2 a:hover, 
+.recent-observations h2 a:hover,
 .recent-observations h2 a {
     color: white;
     text-decoration: none;
@@ -188,7 +188,7 @@ div.minisass-rc-links {
 }
 
 div.blog-leader {
-    border-bottom: 1px dotted lightgray; 
+    border-bottom: 1px dotted lightgray;
     margin-bottom: 1.5em;
     margin-top: 0.5em;
 }
@@ -386,4 +386,12 @@ div.minisass-page-content p {
 }
 div.cmsplugin_filer_folder_slidshow {
     height: 235px !important;
+}
+
+.news-ticker {
+    float: left;
+    height: 30px;
+    width: 1024px;
+    border: 1px solid #bbbbbb;
+    margin: 5px 10px 5px 0px;
 }

--- a/minisass/static/css/marquee.css
+++ b/minisass/static/css/marquee.css
@@ -1,0 +1,49 @@
+/* Make it a marquee */
+.marquee {
+    width: 1024px;
+    margin: 0 auto;
+    overflow: hidden;
+    white-space: nowrap;
+    box-sizing: border-box;
+    animation: marquee 50s linear infinite;
+}
+
+.marquee:hover {
+    animation-play-state: paused
+}
+
+/* Make it move */
+@keyframes marquee {
+    0%   { text-indent: 27.5em }
+    100% { text-indent: -105em }
+}
+
+/* Make it pretty */
+.microsoft {
+    padding-left: 1.5em;
+    position: relative;
+    font: 16px 'Segoe UI', Tahoma, Helvetica, Sans-Serif;
+}
+
+/* Style the links */
+.vanity {
+    color: #333;
+    text-align: center;
+    font: .75em 'Segoe UI', Tahoma, Helvetica, Sans-Serif;
+}
+
+.vanity a, .microsoft a {
+    color: #1570A6;
+    transition: color .5s;
+    text-decoration: none;
+}
+
+.vanity a:hover, .microsoft a:hover {
+    color: #F65314;
+}
+
+/* Style toggle button */
+.toggle {
+	display: block;
+    margin: 2em auto;
+}

--- a/minisass/static/js/marquee.js
+++ b/minisass/static/js/marquee.js
@@ -1,0 +1,7 @@
+/**
+ * Created by rischan on 10/28/15.
+ */
+
+$(".toggle").on("click", function () {
+    $(".marquee").toggleClass("microsoft");
+});

--- a/minisass/templates/base.html
+++ b/minisass/templates/base.html
@@ -2,24 +2,35 @@
 <!doctype html>
 <html>
   <head>
-    {% addtoblock "css" %}<link rel="stylesheet" type="text/css" href="http://fonts.googleapis.com/css?family=Coming+Soon">{% endaddtoblock %}
-    {% addtoblock "css" %}<link href="{{STATIC_URL}}css/normalize.css" media="screen, print" rel="stylesheet">{% endaddtoblock %}
-    {% addtoblock "css" %}<link href="{{STATIC_URL}}css/minisass-menu.css" media="screen, print" rel="stylesheet">{% endaddtoblock %}
-    {% addtoblock "css" %}<link href="{{STATIC_URL}}css/base.css" media="screen, print" rel="stylesheet">{% endaddtoblock %}
+    {% addtoblock "css" %}
+        <link rel="stylesheet" type="text/css"
+              href="http://fonts.googleapis.com/css?family=Coming+Soon">{% endaddtoblock %}
+    {% addtoblock "css" %}
+        <link href="{{ STATIC_URL }}css/normalize.css" media="screen, print" rel="stylesheet">{% endaddtoblock %}
+    {% addtoblock "css" %}
+        <link href="{{ STATIC_URL }}css/minisass-menu.css" media="screen, print" rel="stylesheet">{% endaddtoblock %}
+    {% addtoblock "css" %}
+        <link href="{{ STATIC_URL }}css/base.css" media="screen, print" rel="stylesheet">{% endaddtoblock %}
+    {% addtoblock "css" %}
+        <link href="{{ STATIC_URL }}css/marquee.css" media="screen, print" rel="stylesheet">{% endaddtoblock %}
     {% block "minisass_css" %}
     {% endblock %}
     {% render_block "css" %}
 
-    {% addtoblock "js" %}<script src="http://code.jquery.com/jquery-1.7.2.min.js"></script>{% endaddtoblock %}
-    {% addtoblock "js" %}<script src="{{STATIC_URL}}js/jqueryslidemenu.js"></script>{% endaddtoblock %}
+    {% addtoblock "js" %}
+        <script src="http://code.jquery.com/jquery-1.7.2.min.js"></script>{% endaddtoblock %}
+    {% addtoblock "js" %}
+        <script src="{{ STATIC_URL }}js/jqueryslidemenu.js"></script>{% endaddtoblock %}
+    {% addtoblock "js" %}
+        <script src="{{ STATIC_URL }}js/marquee.js"></script>{% endaddtoblock %}
     {% block "minisass_js" %}
     {% endblock %}
     {% render_block "js" %}
 
     <title>
-      {% block "minisass_page_title" %}{% page_attribute "page_title" %}{% endblock %}
+        {% block "minisass_page_title" %}{% page_attribute "page_title" %}{% endblock %}
     </title>
-  </head>
+</head>
   <body>
     {% cms_toolbar %}
 
@@ -47,9 +58,20 @@
           {% endif %}
           </p>
         </div>
+
         <div class="minisass-heading-space">
             {% placeholder "logo_content" %}
         </div>
+
+        {% block banner %}
+       <div class="news-ticker">
+            <p class="microsoft marquee">
+                {% placeholder "news_ticker_content" or %}There is no Marquee text in database.{% endplaceholder %}
+           </p>
+        </div>
+      {% endblock %}
+
+
         <div id="myslidemenu">
           <ul class="minisass-menus">
             {% show_menu 0 100 100 100 %}
@@ -58,6 +80,8 @@
 
       <div class="red-line">
       </div>
+
+
 
       <div class="minisass-page">
 

--- a/minisass/templates/news_ticker_content.html
+++ b/minisass/templates/news_ticker_content.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% load cms_tags %}
+
+{% block banner %}
+{% placeholder "news_ticker_content" %}
+{% endblock %}

--- a/minisass_registration/fixtures/initial_data.json
+++ b/minisass_registration/fixtures/initial_data.json
@@ -1,161 +1,1801 @@
 [
   {
-    "pk": 1, 
-    "model": "minisass_registration.lookup", 
+    "pk": 1,
+    "model": "minisass_registration.lookup",
     "fields": {
-      "active": true, 
-      "container": null, 
-      "description": "Organisation Type", 
+      "active": true,
+      "container": null,
+      "description": "Organisation Type",
       "rank": 0
     }
-  }, 
+  },
   {
-    "pk": 3, 
-    "model": "minisass_registration.lookup", 
+    "pk": 3,
+    "model": "minisass_registration.lookup",
     "fields": {
-      "active": true, 
-      "container": 1, 
-      "description": "NGO", 
+      "active": true,
+      "container": 1,
+      "description": "NGO",
       "rank": 1
     }
-  }, 
+  },
   {
-    "pk": 4, 
-    "model": "minisass_registration.lookup", 
+    "pk": 4,
+    "model": "minisass_registration.lookup",
     "fields": {
-      "active": true, 
-      "container": 1, 
-      "description": "Conservancy", 
+      "active": true,
+      "container": 1,
+      "description": "Conservancy",
       "rank": 2
     }
-  }, 
+  },
   {
-    "pk": 5, 
-    "model": "minisass_registration.lookup", 
+    "pk": 5,
+    "model": "minisass_registration.lookup",
     "fields": {
-      "active": true, 
-      "container": 1, 
-      "description": "Government Department", 
+      "active": true,
+      "container": 1,
+      "description": "Government Department",
       "rank": 4
     }
-  }, 
+  },
   {
-    "pk": 6, 
-    "model": "minisass_registration.lookup", 
+    "pk": 6,
+    "model": "minisass_registration.lookup",
     "fields": {
-      "active": true, 
-      "container": 1, 
-      "description": "Private Individual", 
+      "active": true,
+      "container": 1,
+      "description": "Private Individual",
       "rank": 3
     }
-  }, 
+  },
   {
-    "pk": 2, 
-    "model": "minisass_registration.lookup", 
+    "pk": 2,
+    "model": "minisass_registration.lookup",
     "fields": {
-      "active": true, 
-      "container": 1, 
-      "description": "School", 
+      "active": true,
+      "container": 1,
+      "description": "School",
       "rank": 0
     }
-  }, 
+  },
   {
-    "pk": 8, 
-    "model": "minisass_registration.lookup", 
+    "pk": 8,
+    "model": "minisass_registration.lookup",
     "fields": {
-      "active": true, 
-      "container": null, 
-      "description": "Country", 
+      "active": true,
+      "container": null,
+      "description": "Country",
       "rank": 0
     }
-  }, 
+  },
   {
-    "pk": 9, 
-    "model": "minisass_registration.lookup", 
+    "pk": 9,
+    "model": "minisass_registration.lookup",
     "fields": {
-      "active": true, 
-      "container": 8, 
-      "description": "South Africa", 
+      "active": true,
+      "container": 8,
+      "description": "South Africa",
       "rank": 0
     }
-  }, 
+  },
   {
-    "pk": 10, 
-    "model": "minisass_registration.lookup", 
+    "pk": 10,
+    "model": "minisass_registration.lookup",
     "fields": {
-      "active": true, 
-      "container": 8, 
-      "description": "Namibia", 
+      "active": true,
+      "container": 8,
+      "description": "Namibia",
       "rank": 0
     }
-  }, 
+  },
   {
-    "pk": 11, 
-    "model": "minisass_registration.lookup", 
+    "pk": 11,
+    "model": "minisass_registration.lookup",
     "fields": {
-      "active": true, 
-      "container": 8, 
-      "description": "Lesotho", 
+      "active": true,
+      "container": 8,
+      "description": "Lesotho",
       "rank": 0
     }
-  }, 
+  },
   {
-    "pk": 12, 
-    "model": "minisass_registration.lookup", 
+    "pk": 12,
+    "model": "minisass_registration.lookup",
     "fields": {
-      "active": true, 
-      "container": 8, 
-      "description": "Swaziland", 
+      "active": true,
+      "container": 8,
+      "description": "Swaziland",
       "rank": 0
     }
-  }, 
+  },
   {
-    "pk": 13, 
-    "model": "minisass_registration.lookup", 
+    "pk": 13,
+    "model": "minisass_registration.lookup",
     "fields": {
-      "active": true, 
-      "container": 8, 
-      "description": "Botswana", 
+      "active": true,
+      "container": 8,
+      "description": "Botswana",
       "rank": 0
     }
-  }, 
+  },
   {
-    "pk": 14, 
-    "model": "minisass_registration.lookup", 
+    "pk": 14,
+    "model": "minisass_registration.lookup",
     "fields": {
-      "active": true, 
-      "container": 8, 
-      "description": "Zimbabwe", 
+      "active": true,
+      "container": 8,
+      "description": "Zimbabwe",
       "rank": 0
     }
-  }, 
+  },
   {
-    "pk": 15, 
-    "model": "minisass_registration.lookup", 
+    "pk": 15,
+    "model": "minisass_registration.lookup",
     "fields": {
-      "active": true, 
-      "container": 8, 
-      "description": "Mozambique", 
+      "active": true,
+      "container": 8,
+      "description": "Mozambique",
       "rank": 0
     }
-  }, 
+  },
   {
-    "pk": 16, 
-    "model": "minisass_registration.lookup", 
+    "pk": 16,
+    "model": "minisass_registration.lookup",
     "fields": {
-      "active": true, 
-      "container": 8, 
-      "description": "Angola", 
+      "active": true,
+      "container": 8,
+      "description": "Angola",
       "rank": 0
     }
-  }, 
+  },
   {
-    "pk": 17, 
-    "model": "minisass_registration.lookup", 
+    "pk": 17,
+    "model": "minisass_registration.lookup",
     "fields": {
-      "active": true, 
-      "container": 8, 
-      "description": "Malawi", 
+      "active": true,
+      "container": 8,
+      "description": "Malawi",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 18,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Mauritania",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 19,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Malaysia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 20,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Andorra",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 21,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "United Arab Emirates",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 22,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Afghanistan",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 23,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Antigua and Barbuda",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 24,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Anguilla",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 25,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Albania",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 26,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Armenia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 27,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Antarctica",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 28,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Argentina",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 29,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "American Samoa",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 30,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Austria",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 31,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Australia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 32,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Aruba",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 33,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Åland",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 34,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Azerbaijan",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 35,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Bosnia and Herzegovina",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 36,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Barbados",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 37,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Bangladesh",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 38,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Belgium",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 39,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Burkina Faso",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 40,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Bulgaria",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 41,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Bahrain",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 42,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Burundi",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 43,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Benin",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 44,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Saint Barthélemy",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 45,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Bermuda",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 46,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Brunei",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 47,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Bolivia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 48,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Bonaire",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 49,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Brazil",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 50,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Bahamas",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 51,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Bhutan",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 52,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Bouvet Island",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 53,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Belarus",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 54,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Belize",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 55,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Canada",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 56,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Cocos",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 57,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Republic of the Congo",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 58,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Central African Republic",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 59,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Switzerland",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 60,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Ivory Coast",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 61,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Cook Islands",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 62,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Chile",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 63,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Cameroon",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 64,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "China",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 65,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Colombia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 66,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Costa Rica",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 67,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Cuba",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 68,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Cape Verde",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 69,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Cyprus",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 70,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Czech Republic",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 71,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Germany",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 72,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Djibouti",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 73,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Denmark",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 74,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Dominica",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 75,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Algeria",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 76,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Ecuador",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 77,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Estonia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 78,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Egypt",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 79,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Western Sahara",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 80,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Eritrea",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 81,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Spain",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 82,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Ethiopia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 83,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Finland",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 84,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Fiji",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 85,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "France",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 86,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Gabon",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 87,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "United Kingdom",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 88,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Grenada",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 89,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Georgia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 90,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Guernsey",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 91,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Ghana",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 92,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Gibraltar",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 93,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Greenland",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 94,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Gambia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 95,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Guinea",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 96,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Guadeloupe",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 97,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Greece",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 98,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Hungary",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 99,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Ireland",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 100,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Israel",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 101,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "India",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 102,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Iraq",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 103,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Iran",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 104,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Italy",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 105,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Jersey",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 106,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Jamaica",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 107,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Jordan",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 108,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Japan",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 109,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Kenya",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 110,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Kyrgyzstan",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 111,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Cambodia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 112,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Kiribati",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 113,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Comoros",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 114,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "North Korea",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 115,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "South Korea",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 116,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Kuwait",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 117,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Kazakhstan",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 118,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Laos",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 119,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Lebanon",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 120,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Liechtenstein",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 121,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Sri Lanka",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 122,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Liberia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 123,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Lithuania",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 124,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Luxembourg",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 125,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Latvia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 126,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Libya",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 127,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Morocco",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 128,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Monaco",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 129,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Moldova",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 130,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Montenegro",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 131,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Myanmar",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 132,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Mongolia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 133,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Mexico",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 134,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Nigeria",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 135,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Netherlands",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 136,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Norway",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 137,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Nepal",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 138,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "New Zealand",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 139,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Oman",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 140,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Peru",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 141,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Papua New Guinea",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 142,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Philippines",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 143,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Pakistan",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 144,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Poland",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 145,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Palestine",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 146,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Portugal",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 147,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Palau",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 148,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Paraguay",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 149,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Qatar",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 150,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Romania",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 151,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Serbia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 152,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Russia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 153,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Rwanda",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 154,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Sudan",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 155,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Sweden",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 156,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Singapore",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 157,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Slovenia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 158,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Chad",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 159,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Suriname",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 160,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Syria",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 161,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Thailand",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 162,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Tajikistan",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 163,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "East Timor",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 164,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Turkmenistan",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 165,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Tunisia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 166,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Turkey",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 167,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Indonesia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 168,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Taiwan",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 169,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Tanzania",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 170,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Ukraine",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 171,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Uganda",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 172,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "United States",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 173,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Uruguay",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 174,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Uzbekistan",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 175,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Venezuela",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 176,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Vietnam",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 177,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Samoa",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 178,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Kosovo",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 179,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Yemen",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 180,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Mayotte",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 181,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Zambia",
       "rank": 0
     }
   }

--- a/minisass_registration/fixtures/initial_data.json
+++ b/minisass_registration/fixtures/initial_data.json
@@ -76,7 +76,7 @@
       "active": true,
       "container": 8,
       "description": "South Africa",
-      "rank": 396
+      "rank": 1
     }
   },
   {
@@ -96,7 +96,7 @@
       "active": true,
       "container": 8,
       "description": "Lesotho",
-      "rank": 8
+      "rank": 3
     }
   },
   {
@@ -106,7 +106,7 @@
       "active": true,
       "container": 8,
       "description": "Swaziland",
-      "rank": 3
+      "rank": 6
     }
   },
   {
@@ -116,7 +116,7 @@
       "active": true,
       "container": 8,
       "description": "Botswana",
-      "rank": 1
+      "rank": 12
     }
   },
   {
@@ -126,7 +126,7 @@
       "active": true,
       "container": 8,
       "description": "Zimbabwe",
-      "rank": 7
+      "rank": 4
     }
   },
   {
@@ -136,7 +136,7 @@
       "active": true,
       "container": 8,
       "description": "Mozambique",
-      "rank": 1
+      "rank": 11
     }
   },
   {
@@ -156,7 +156,7 @@
       "active": true,
       "container": 8,
       "description": "Malawi",
-      "rank": 2
+      "rank": 9
     }
   },
   {
@@ -1676,7 +1676,7 @@
       "active": true,
       "container": 8,
       "description": "Tanzania",
-      "rank": 2
+      "rank": 8
     }
   },
   {
@@ -1796,7 +1796,7 @@
       "active": true,
       "container": 8,
       "description": "Zambia",
-      "rank": 2
+      "rank": 10
     }
   },
   {
@@ -1806,7 +1806,7 @@
       "active": true,
       "container": 8,
       "description": "Democratic Republic of the Congo",
-      "rank": 3
+      "rank": 7
     }
   },
   {
@@ -2376,7 +2376,7 @@
       "active": true,
       "container": 8,
       "description": "Other",
-      "rank": 17
+      "rank": 2
     }
   }
 ]

--- a/minisass_registration/fixtures/initial_data.json
+++ b/minisass_registration/fixtures/initial_data.json
@@ -76,7 +76,7 @@
       "active": true,
       "container": 8,
       "description": "South Africa",
-      "rank": 0
+      "rank": 396
     }
   },
   {
@@ -86,7 +86,7 @@
       "active": true,
       "container": 8,
       "description": "Namibia",
-      "rank": 0
+      "rank": 5
     }
   },
   {
@@ -96,7 +96,7 @@
       "active": true,
       "container": 8,
       "description": "Lesotho",
-      "rank": 0
+      "rank": 8
     }
   },
   {
@@ -106,7 +106,7 @@
       "active": true,
       "container": 8,
       "description": "Swaziland",
-      "rank": 0
+      "rank": 3
     }
   },
   {
@@ -116,7 +116,7 @@
       "active": true,
       "container": 8,
       "description": "Botswana",
-      "rank": 0
+      "rank": 1
     }
   },
   {
@@ -126,7 +126,7 @@
       "active": true,
       "container": 8,
       "description": "Zimbabwe",
-      "rank": 0
+      "rank": 7
     }
   },
   {
@@ -136,7 +136,7 @@
       "active": true,
       "container": 8,
       "description": "Mozambique",
-      "rank": 0
+      "rank": 1
     }
   },
   {
@@ -156,7 +156,7 @@
       "active": true,
       "container": 8,
       "description": "Malawi",
-      "rank": 0
+      "rank": 2
     }
   },
   {
@@ -1676,7 +1676,7 @@
       "active": true,
       "container": 8,
       "description": "Tanzania",
-      "rank": 0
+      "rank": 2
     }
   },
   {
@@ -1796,7 +1796,587 @@
       "active": true,
       "container": 8,
       "description": "Zambia",
+      "rank": 2
+    }
+  },
+  {
+    "pk": 182,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Democratic Republic of the Congo",
+      "rank": 3
+    }
+  },
+  {
+    "pk": 183,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Iceland",
       "rank": 0
+    }
+  },
+  {
+    "pk": 184,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Saint Kitts and Nevis",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 185,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Cayman Islands",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 186,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Saint Lucia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 187,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Saint Martin",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 188,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Madagascar",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 189,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Marshall Islands",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 190,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Macedonia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 191,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Mali",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 192,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Macao",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 193,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Northern Mariana Islands",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 194,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Martinique",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 195,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Mauritania",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 196,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Montserrat",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 197,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Malta",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 198,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Mauritius",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 199,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Maldives",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 200,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "New Caledonia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 201,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Norfolk Island",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 202,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Nicaragua",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 203,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Nauru",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 204,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Niue",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 205,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Panama",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 206,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "French Polynesia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 207,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Saint Pierre and Miquelon",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 208,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Pitcairn Islands",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 209,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Puerto Rico",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 210,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Réunion",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 211,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Saudi Arabia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 212,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Solomon Islands",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 213,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Seychelles",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 214,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Saint Helena",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 215,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Svalbard and Jan Mayen",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 216,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Slovakia",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 217,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Sierra Leone",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 218,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "San Marino",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 219,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Senegal",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 220,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "South Sudan",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 221,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "São Tomé and Príncipe",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 222,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "El Salvador",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 223,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Sint Maarten",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 224,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Turks and Caicos Islands",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 225,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Chad",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 226,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "French Southern Territories",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 227,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Togo",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 228,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Tokelau",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 229,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Tonga",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 230,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Trinidad and Tobago",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 231,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Tuvalu",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 232,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "U.S. Minor Outlying Islands",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 233,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Vatican City",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 234,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Saint Vincent and the Grenadines",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 235,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "British Virgin Islands",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 236,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "U.S. Virgin Islands",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 237,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Vanuatu",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 238,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Wallis and Futuna",
+      "rank": 0
+    }
+  },
+  {
+    "pk": 239,
+    "model": "minisass_registration.lookup",
+    "fields": {
+      "active": true,
+      "container": 8,
+      "description": "Other",
+      "rank": 17
     }
   }
 ]


### PR DESCRIPTION
Hi @gubuntu please could you try this? I just worried if something wrong in my local PC because in my PC when I remove some of data from admin it does not effect the index page. So, I worried if there is something wrong in my local PC. This way, Logically it should works. 

I've add placeholder `news_ticker_content` to the admin page. 

Admin can insert `text` to `news_ticker_content` then see the index page. If this one does not work, probably I'll try to looking another way. 

How do you think? 
Thanks
