### PR TITLE
fixing countries order list

### DIFF
--- a/minisass_registration/forms.py
+++ b/minisass_registration/forms.py
@@ -24,7 +24,7 @@ def _get_organisation_names():
 
 def _get_countries():
     result = [('','-- Select a Country --')]
-    qs = Lookup.objects.raw("SELECT * FROM minisass_registration_lookup WHERE container_id='8' AND active ='t' ORDER BY rank = 0, rank" )
+    qs = Lookup.objects.raw("SELECT * FROM minisass_registration_lookup WHERE container_id='8' AND active ='t' ORDER BY rank = 0, rank, description" )
     result.extend([(itm.id, itm.description,) for itm in qs])
     return result
 

--- a/minisass_registration/forms.py
+++ b/minisass_registration/forms.py
@@ -24,10 +24,7 @@ def _get_organisation_names():
 
 def _get_countries():
     result = [('','-- Select a Country --')]
-    qs = Lookup.objects.filter(
-        container__description='Country',
-        active=True)
-    qs = qs.order_by('rank', 'description')
+    qs = Lookup.objects.raw("SELECT * FROM minisass_registration_lookup WHERE container_id='8' AND active ='t' ORDER BY rank = 0, rank" )
     result.extend([(itm.id, itm.description,) for itm in qs])
     return result
 


### PR DESCRIPTION
Hi @gubuntu Previous I used count not rank so I guess I was correct. 
If the country which has no count number, we assign with `0` value then when we select the countries using order by `rank`, of course the country which has `0` value will come up in the top. 

The solution is using quary like this:
`SELECT * FROM minisass_registration_lookup ORDER BY rank = 0, rank`

So, it will order by rank but `0` value will ordered after country which has value not `0`. The problem is I was looking in django model how to order by that giving param like that query but I could not find it. 

In this PR, I use raw query to solved it, how do you think? I've cheked in my computer and it works. 

![screen shot 2015-11-09 at 4 49 11 pm](https://cloud.githubusercontent.com/assets/2235894/11030870/5511fe42-8703-11e5-80f3-1cc75f41d348.png)
