### PR TITLE
added styles for vector tiles

### DIFF
--- a/django_project/webmapping/styles/json/country.json
+++ b/django_project/webmapping/styles/json/country.json
@@ -1,0 +1,34 @@
+{
+    "version": 8,
+    "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
+    "name": "country",
+    "sources": {
+        "vector-source": {
+            "type": "vector",
+            "tiles": [
+                "https://minigauss/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&LAYER=miniSASS:country&STYLE=&TILEMATRIX=EPSG:3857:{z}&TILEMATRIXSET=EPSG:3857&FORMAT=application/vnd.mapbox-vector-tile&TILECOL={x}&TILEROW={y}"
+            ],
+            "minZoom": 0,
+            "maxZoom": 20
+        }
+    },
+    "layers": [
+        {
+            "type": "line",
+            "paint": {
+                "line-width": 0.7,
+                "line-opacity": 1.0,
+                "line-color": "#000000",
+                "line-dasharray": [
+                    5,
+                    2
+                ]
+            },
+            "Z": 0,
+            "source": "vector-source",
+            "source-layer": "country",
+            "id": "country:(rule#0):0"
+        }
+    ],
+    "sprite": "spriteSheet"
+}

--- a/django_project/webmapping/styles/json/dams.json
+++ b/django_project/webmapping/styles/json/dams.json
@@ -1,0 +1,68 @@
+{
+    "version": 8,
+    "glyphs": "https://api.maptiler.com/fonts/{fontstack}/{range}.pbf?key=cc4PpmmWZP73LjU1nsw3",
+    "name": "dams",
+    "sources": {
+        "vector-source": {
+            "type": "vector",
+            "tiles": [
+                "https://minigauss/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&LAYER=miniSASS:dams&STYLE=&TILEMATRIX=EPSG:3857:{z}&TILEMATRIXSET=EPSG:3857&FORMAT=application/vnd.mapbox-vector-tile&TILECOL={x}&TILEROW={y}"
+            ],
+            "minZoom": 0,
+            "maxZoom": 20
+        }
+    },
+    "layers": [
+        {
+            "type": "fill",
+            "paint": {
+                "fill-opacity": 1.0,
+                "fill-color": "#d3e5f3"
+            },
+            "Z": 0,
+            "source": "vector-source",
+            "source-layer": "dams",
+            "id": "dams:(rule#0)Dam-with-label:0",
+            "minzoom": 7.542161335390952,
+            "maxzoom": 24
+        },
+        {
+            "type": "line",
+            "paint": {
+                "line-width": 0.1,
+                "line-opacity": 1.0,
+                "line-color": "#6998c9"
+            },
+            "Z": 0,
+            "source": "vector-source",
+            "source-layer": "dams",
+            "id": "dams:(rule#0)Dam-with-label:1",
+            "minzoom": 7.542161335390952,
+            "maxzoom": 24
+        },
+        {
+            "type": "fill",
+            "paint": {
+                "fill-opacity": 1.0,
+                "fill-color": "#d3e5f3"
+            },
+            "Z": 0,
+            "source": "vector-source",
+            "source-layer": "dams",
+            "id": "dams:(rule#1)Dam:0"
+        },
+        {
+            "type": "line",
+            "paint": {
+                "line-width": 0.1,
+                "line-opacity": 1.0,
+                "line-color": "#6998c9"
+            },
+            "Z": 0,
+            "source": "vector-source",
+            "source-layer": "dams",
+            "id": "dams:(rule#1)Dam:1"
+        }
+    ],
+    "sprite": "spriteSheet"
+}

--- a/django_project/webmapping/styles/json/districts.json
+++ b/django_project/webmapping/styles/json/districts.json
@@ -1,0 +1,54 @@
+{
+    "version": 8,
+    "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
+    "name": "districts",
+    "sources": {
+        "vector-source": {
+            "type": "vector",
+            "tiles": [
+                "https://minigauss/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&LAYER=miniSASS:districts&STYLE=&TILEMATRIX=EPSG:3857:{z}&TILEMATRIXSET=EPSG:3857&FORMAT=application/vnd.mapbox-vector-tile&TILECOL={x}&TILEROW={y}"
+            ],
+            "minZoom": 0,
+            "maxZoom": 20
+        }
+    },
+    "layers": [
+        {
+            "type": "line",
+            "paint": {
+                "line-width": 0.86,
+                "line-opacity": 1.0,
+                "line-color": "#aaaa7f",
+                "line-dasharray": [
+                    5,
+                    2
+                ]
+            },
+            "Z": 0,
+            "source": "vector-source",
+            "source-layer": "districts",
+            "id": "districts:(rule#0)District_municipalities_with_label:0",
+            "minzoom": 6.542161335390952,
+            "maxzoom": 8.864089430278314
+        },
+        {
+            "type": "line",
+            "paint": {
+                "line-width": 0.86,
+                "line-opacity": 1.0,
+                "line-color": "#aaaa7f",
+                "line-dasharray": [
+                    5,
+                    2
+                ]
+            },
+            "Z": 0,
+            "source": "vector-source",
+            "source-layer": "districts",
+            "id": "districts:(rule#1)District_municipalities:0",
+            "minzoom": 24,
+            "maxzoom": 8.864089430278314
+        }
+    ],
+    "sprite": "spriteSheet"
+}

--- a/django_project/webmapping/styles/json/hca1.json
+++ b/django_project/webmapping/styles/json/hca1.json
@@ -1,0 +1,32 @@
+{
+    "version": 8,
+    "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
+    "name": "hca1",
+    "sources": {
+        "vector-source": {
+            "type": "vector",
+            "tiles": [
+                "https://minigauss/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&LAYER=miniSASS:hca1&STYLE=&TILEMATRIX=EPSG:3857:{z}&TILEMATRIXSET=EPSG:3857&FORMAT=application/vnd.mapbox-vector-tile&TILECOL={x}&TILEROW={y}"
+            ],
+            "minZoom": 0,
+            "maxZoom": 20
+        }
+    },
+    "layers": [
+        {
+            "type": "line",
+            "paint": {
+                "line-width": 0.2,
+                "line-opacity": 0.2980392156862745,
+                "line-color": "#ff0045"
+            },
+            "Z": 0,
+            "source": "vector-source",
+            "source-layer": "hca1",
+            "id": "hca1:(rule#0)hca1:0",
+            "minzoom": 5.319768914054504,
+            "maxzoom": 8.279126929557158
+        }
+    ],
+    "sprite": "spriteSheet"
+}

--- a/django_project/webmapping/styles/json/hca2.json
+++ b/django_project/webmapping/styles/json/hca2.json
@@ -1,0 +1,32 @@
+{
+    "version": 8,
+    "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
+    "name": "hca2",
+    "sources": {
+        "vector-source": {
+            "type": "vector",
+            "tiles": [
+                "https://minigauss/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&LAYER=miniSASS:hca2&STYLE=&TILEMATRIX=EPSG:3857:{z}&TILEMATRIXSET=EPSG:3857&FORMAT=application/vnd.mapbox-vector-tile&TILECOL={x}&TILEROW={y}"
+            ],
+            "minZoom": 0,
+            "maxZoom": 20
+        }
+    },
+    "layers": [
+        {
+            "type": "line",
+            "paint": {
+                "line-width": 0.1,
+                "line-opacity": 1.0,
+                "line-color": "#90ee90"
+            },
+            "Z": 0,
+            "source": "vector-source",
+            "source-layer": "hca2",
+            "id": "hca2:(rule#0)hca2:0",
+            "minzoom": 8.279126929557158,
+            "maxzoom": 9.279126929557158
+        }
+    ],
+    "sprite": "spriteSheet"
+}

--- a/django_project/webmapping/styles/json/hca3.json
+++ b/django_project/webmapping/styles/json/hca3.json
@@ -1,0 +1,32 @@
+{
+    "version": 8,
+    "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
+    "name": "hca3",
+    "sources": {
+        "vector-source": {
+            "type": "vector",
+            "tiles": [
+                "https://minigauss/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&LAYER=miniSASS:hca3&STYLE=&TILEMATRIX=EPSG:3857:{z}&TILEMATRIXSET=EPSG:3857&FORMAT=application/vnd.mapbox-vector-tile&TILECOL={x}&TILEROW={y}"
+            ],
+            "minZoom": 0,
+            "maxZoom": 20
+        }
+    },
+    "layers": [
+        {
+            "type": "line",
+            "paint": {
+                "line-width": 0.1,
+                "line-opacity": 1.0,
+                "line-color": "#a52a2a"
+            },
+            "Z": 0,
+            "source": "vector-source",
+            "source-layer": "hca3",
+            "id": "hca3:(rule#0)hca3:0",
+            "minzoom": 9.279126929557158,
+            "maxzoom": 10.864089430278314
+        }
+    ],
+    "sprite": "spriteSheet"
+}

--- a/django_project/webmapping/styles/json/hca4.json
+++ b/django_project/webmapping/styles/json/hca4.json
@@ -1,0 +1,32 @@
+{
+    "version": 8,
+    "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
+    "name": "hca4",
+    "sources": {
+        "vector-source": {
+            "type": "vector",
+            "tiles": [
+                "https://minigauss/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&LAYER=miniSASS:hca4&STYLE=&TILEMATRIX=EPSG:3857:{z}&TILEMATRIXSET=EPSG:3857&FORMAT=application/vnd.mapbox-vector-tile&TILECOL={x}&TILEROW={y}"
+            ],
+            "minZoom": 0,
+            "maxZoom": 20
+        }
+    },
+    "layers": [
+        {
+            "type": "line",
+            "paint": {
+                "line-width": 0.1,
+                "line-opacity": 1.0,
+                "line-color": "#ff6c00"
+            },
+            "Z": 0,
+            "source": "vector-source",
+            "source-layer": "hca4",
+            "id": "hca4:(rule#0)hca4:0",
+            "minzoom": 10.864089430278314,
+            "maxzoom": 12.449051930999468
+        }
+    ],
+    "sprite": "spriteSheet"
+}

--- a/django_project/webmapping/styles/json/hca5.json
+++ b/django_project/webmapping/styles/json/hca5.json
@@ -1,0 +1,32 @@
+{
+    "version": 8,
+    "glyphs": "mapbox://fonts/mapbox/{fontstack}/{range}.pbf",
+    "name": "hca5",
+    "sources": {
+        "vector-source": {
+            "type": "vector",
+            "tiles": [
+                "https://minigauss/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&LAYER=miniSASS:hca5&STYLE=&TILEMATRIX=EPSG:3857:{z}&TILEMATRIXSET=EPSG:3857&FORMAT=application/vnd.mapbox-vector-tile&TILECOL={x}&TILEROW={y}"
+            ],
+            "minZoom": 0,
+            "maxZoom": 20
+        }
+    },
+    "layers": [
+        {
+            "type": "line",
+            "paint": {
+                "line-width": 0.1,
+                "line-opacity": 1.0,
+                "line-color": "#8a2be2"
+            },
+            "Z": 0,
+            "source": "vector-source",
+            "source-layer": "hca5",
+            "id": "hca5:(rule#0)hca5:0",
+            "minzoom": 12.449051930999468,
+            "maxzoom": 24
+        }
+    ],
+    "sprite": "spriteSheet"
+}


### PR DESCRIPTION
Currently, we are using the WMS layer for rendering map layers and interactions, we are going to migrate to vector tiles in the front end.

Example in QGIS

![image](https://github.com/kartoza/miniSASS/assets/2510900/a7727691-bff1-461f-b1df-51dfa813349e)

Vector tiles URL: https://${HOST_URL}/geoserver/gwc/service/wmts?REQUEST=GetTile&SERVICE=WMTS&VERSION=1.0.0&LAYER=miniSASS:dams&STYLE=&TILEMATRIX=EPSG:3857:{z}&TILEMATRIXSET=EPSG:3857&FORMAT=application/vnd.mapbox-vector-tile&TILECOL={x}&TILEROW={y}

#TODO

- [ ] Add labelling options for vector styles
- [ ] Convert minisass observations to json styling



