### PR TITLE
patch: fix open layers template not found issue

### DIFF
--- a/django_project/minisass/settings.py
+++ b/django_project/minisass/settings.py
@@ -187,7 +187,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.admin',
-    # 'django.contrib.gis',
+    'django.contrib.gis',
     # custom apps here:
     'rest_framework',
     'rest_framework_simplejwt',


### PR DESCRIPTION
Description: 
bacause this app was disabled  user was unable to add a site in the django admin ,it was returning template does not exist error


https://github.com/kartoza/miniSASS/assets/70011086/f4740cad-4727-4e5c-abf7-c1b79559f1ac

