### PR TITLE
patch: adjust variable name

### DIFF
--- a/django_project/minisass/settings.py
+++ b/django_project/minisass/settings.py
@@ -160,7 +160,7 @@ EMAIL_PORT = os.getenv('SMTP_PORT', '25')
 EMAIL_HOST_USER = os.getenv('SMTP_HOST_USER', 'noreply@kartoza.com')
 EMAIL_HOST_PASSWORD = os.getenv('SMTP_HOST_PASSWORD', 'docker')
 EMAIL_USE_TLS = os.getenv('SMTP_EMAIL_TLS', 'False')
-EMAIL_USE_SSL = os.getenv('SMTP_EMAIL_TLS', 'False')
+EMAIL_USE_SSL = os.getenv('SMTP_EMAIL_SSL', 'False')
 
 SERVER_EMAIL = os.environ.get('SMTP_EMAIL', 'noreply@kartoza.com')
 CONTACT_US_RECEPIENT_EMAIL = 'amy@kartoza.com'


### PR DESCRIPTION
Description:

on sending email this error was being reported because both variables were being assigned the same env var

![email_error](https://github.com/kartoza/miniSASS/assets/70011086/d9dfca79-319f-44b5-bc6f-98f908c4a692)

this has been resolved