### PR TITLE
Update styles of map

### DIFF
--- a/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
+++ b/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
@@ -7,7 +7,7 @@ import { Instance } from '@popperjs/core';
 import { Formik, Form, Field } from 'formik';
 import ScoreForm from "../../components/ScoreForm";
 import axios from "axios";
-import { globalVariables } from "../../utils";
+import { globalVariables, formatDate } from "../../utils";
 import CoordinatesInputForm from "../CoordinatesInputForm";
 
 
@@ -539,6 +539,8 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
                         padding: '8px 12px',
                         marginRight: '-10px'
                       }}
+                      min={'2010-01-01'}
+                      max={formatDate(new Date())}
                       value={values.date}
                       onChange={handleChange}
                     />

--- a/django_project/minisass_frontend/src/components/Map/Layer/MinisassLayer.tsx
+++ b/django_project/minisass_frontend/src/components/Map/Layer/MinisassLayer.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect, useState } from "react";
+import { FormControlLabel } from "@mui/material";
+import Checkbox from "@mui/material/Checkbox";
+import maplibregl from "maplibre-gl";
+import { hideLayer, showLayer } from "../utils";
+
+interface Interface {
+  map: maplibregl.Map,
+}
+
+export const minisassObservationId = 'MiniSASS Observations'
+
+/**
+ * MiniSASS Layer component
+ */
+export default function MinisassLayer({ map }: Interface) {
+  const [active, setActive] = useState<boolean>(true);
+  const disabled = false
+
+  /** First initiate */
+  useEffect(() => {
+    map.getStyle().layers.map(layer => {
+      if (layer.source === minisassObservationId) {
+        if (active) {
+          showLayer(map, layer.id)
+        } else {
+          hideLayer(map, layer.id)
+        }
+      }
+    })
+  }, [active]);
+
+  return <>
+    <FormControlLabel
+      disabled={disabled}
+      control={
+        <Checkbox
+          checked={active}
+          onChange={evt => {
+            setActive(!active)
+          }}/>
+      }
+      label={'miniSASS Observations'}
+    />
+    <br/>
+  </>
+}

--- a/django_project/minisass_frontend/src/components/Map/Layer/Selector.tsx
+++ b/django_project/minisass_frontend/src/components/Map/Layer/Selector.tsx
@@ -4,6 +4,7 @@ import LayersIcon from "../../../../static/icons/LayersIcon";
 
 import Basemap, { BasemapConfiguration } from "./Basemap"
 import Overlay, { layerConfiguration } from "./Overlay"
+import MiniSassLayer from "./MinisassLayer";
 
 import "./style.css"
 
@@ -60,6 +61,7 @@ export default function Selector(props: Interface) {
       />
       <br/>
       <div className="font-bold mb-[0.5rem]">Overlay Layer</div>
+      <MiniSassLayer map={props.map}/>
       {
         props.overlayLayers.map(
           (layerConfig, idx) => {

--- a/django_project/minisass_frontend/src/components/Map/utils.tsx
+++ b/django_project/minisass_frontend/src/components/Map/utils.tsx
@@ -26,6 +26,32 @@ export const removeLayer = (map: maplibregl.Map, id: string) => {
 }
 
 /**
+ * Show layer from map
+ * @param {Object} map Map
+ * @param {String} id of layer
+ */
+export const showLayer = (map: maplibregl.Map, id: string) => {
+  if (hasLayer(map, id)) {
+    map.setLayoutProperty(
+      id, 'visibility', 'visible'
+    );
+  }
+}
+
+/**
+ * Hide layer from map
+ * @param {Object} map Map
+ * @param {String} id of layer
+ */
+export const hideLayer = (map: maplibregl.Map, id: string) => {
+  if (hasLayer(map, id)) {
+    map.setLayoutProperty(
+      id, 'visibility', 'none'
+    );
+  }
+}
+
+/**
  * Return if source exist
  * @param {Object} map Map
  * @param {String} id of layer

--- a/django_project/minisass_frontend/src/pages/Map/config/overlay.config.json
+++ b/django_project/minisass_frontend/src/pages/Map/config/overlay.config.json
@@ -1,10 +1,1 @@
-[
-  {
-    "name": "miniSASS Observations",
-    "tiles": [
-      "https://minisass.org/geoserver/wms?LAYERS=miniSASS%3Aminisass_observations&TRANSPARENT=TRUE&FORMAT=image%2Fpng&SERVICE=WMS&VERSION=1.1.1&REQUEST=GetMap&STYLES=&SRS=EPSG%3A3857&BBOX={bbox-epsg-3857}&WIDTH=512&HEIGHT=512"
-    ],
-    "type": "raster",
-    "activeByDefault": true
-  }
-]
+[]

--- a/django_project/minisass_frontend/src/utils/index.tsx
+++ b/django_project/minisass_frontend/src/utils/index.tsx
@@ -26,3 +26,19 @@ export const globalVariables = {
   staticPath,
 };
 
+/** Format date */
+export function formatDate(d, reverseDate = false) {
+  let month = '' + (d.getMonth() + 1),
+    day = '' + d.getDate(),
+    year = d.getFullYear();
+
+  if (month.length < 2)
+    month = '0' + month;
+  if (day.length < 2)
+    day = '0' + day;
+  if (reverseDate) {
+    return [day, month, year].join('-');
+  } else {
+    return [year, month, day].join('-');
+  }
+}


### PR DESCRIPTION
This will fixes https://github.com/kartoza/miniSASS/issues/276, fixed https://github.com/kartoza/miniSASS/issues/296

1. We limit the date from 2010-01-01 until today
![Selection_027](https://github.com/kartoza/miniSASS/assets/4530905/a5113031-20f0-459e-ac26-8e152b25ba1d)
![Selection_028](https://github.com/kartoza/miniSASS/assets/4530905/767fc259-511a-4fce-9936-342518735a86)

2. Update style to use : https://raw.githubusercontent.com/kartoza/miniSASS/main/django_project/webmapping/styles/minisass_style_v1.json

The URL will change from https://minisass.dev.do.kartoza.com/tiles/public.minisass_observations/{z}/{x}/{y}.pbf to current domain.
Example if we are in  https://minisass.sta.do.kartoza.com/, it will change to https://minisass.sta.do.kartoza.com/tiles/public.minisass_observations/{z}/{x}/{y}.pbf

![Selection_026](https://github.com/kartoza/miniSASS/assets/4530905/25c27cf3-c02f-45ce-a7b9-1d8631595ca3)

