### PR TITLE
UI fixes 2

### DIFF
--- a/django_project/minisass_frontend/src/components/AuthenticationButtons/index.tsx
+++ b/django_project/minisass_frontend/src/components/AuthenticationButtons/index.tsx
@@ -88,13 +88,12 @@ function AuthenticationButtons() {
       });
   
       if (response.status === 201) {
-        setError(false)
         setLoading(true)
         // Simulate 2-second delay for registration process
         setTimeout(() => {
           setLoading(false);
           setRegistrationInProgress(true);
-        }, 1100);
+        }, 1200);
       } else {
         setError( JSON.stringify(response.data));
       }

--- a/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
+++ b/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
@@ -220,7 +220,7 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
     <>
       {!showScoreForm ? (
       <div className={props.className} style={{
-        height: '72.5vh',
+        height: '75vh',
         overflowY: 'auto',
         overflowX: 'auto',
       }}>

--- a/django_project/minisass_frontend/src/components/PasswordResetForm/index.tsx
+++ b/django_project/minisass_frontend/src/components/PasswordResetForm/index.tsx
@@ -1,12 +1,16 @@
 import React, { useState } from "react";
 import axios from "axios";
 import { Button } from "../../components/Button";
+import { globalVariables } from "../../utils";
+
 
 const PasswordResetForm = ({ uid = "", token = "" }) => {
   const [newPassword, setNewPassword] = useState("");
   const [repeatPassword, setRepeatPassword] = useState("");
   const [resetErrors, setResetErrors] = useState<string[]>([]);
   const [textColor, settextColor] = useState('');
+
+  const PASSWORD_RESET_API = globalVariables.baseUrl + '/authentication/api/update-password-reset/'
 
   const handleResetPassword = async () => {
     if (newPassword !== repeatPassword) {
@@ -16,7 +20,7 @@ const PasswordResetForm = ({ uid = "", token = "" }) => {
 
     try {
       const response = await axios.post(
-        `${window.location.origin}/authentication/api/update-password-reset`,
+        `${PASSWORD_RESET_API}`,
         { newPassword, uid, token }
       );
 

--- a/django_project/minisass_frontend/src/components/RegistrationFormModal/index.tsx
+++ b/django_project/minisass_frontend/src/components/RegistrationFormModal/index.tsx
@@ -286,7 +286,7 @@ const RegistrationFormModal: React.FC<RegistrationFormModalProps> = ({
               color="blue_gray_500"
               size="xs"
               variant="fill"
-              style={{ marginLeft: "60%" }}
+              style={{ marginLeft: "65%" }}
               onClick={onClose}
             >
               Ok

--- a/django_project/minisass_frontend/src/components/ScoreForm/index.tsx
+++ b/django_project/minisass_frontend/src/components/ScoreForm/index.tsx
@@ -159,7 +159,7 @@ const ScoreForm: FC<ScoreFormProps> = ({ onCancel, additionalData, setSidebarOpe
     <>
       <div className="flex flex-col font-raleway items-center justify-start mx-auto p-0.5 w-full"
         style={{
-          height: '72.5vh',
+          height: '75vh',
           overflowY: 'auto',
           overflowX: 'auto'
         }}


### PR DESCRIPTION
![modal](https://github.com/kartoza/miniSASS/assets/70011086/c0c5bf5a-e327-492a-899d-fee9366c097a)

Description
I have increased the modal height for data input and score form , they now fill the entire map area and leave a little gap as before
The registration loader was not showing this was caused by a previous statement setError(false)
when updating the password from the reset link it was throwing a 404 error due to a missing trailing slash on the url