### PR TITLE
Fix missing logo in email and invalid reset link

### DIFF
--- a/django_project/minisass_authentication/templates/registration/activate_account.html
+++ b/django_project/minisass_authentication/templates/registration/activate_account.html
@@ -8,7 +8,7 @@
     <div style="max-width: 600px; margin: 20px auto; padding: 20px; background-color: #fff; border-radius: 8px; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);">
         <!-- Logo -->
         <div style="text-align: center; margin-bottom: 20px;">
-            <img src="{{ logo }}" alt="Company Logo" style="max-width: 200px; height: auto;">
+            <img src="https://{{ domain }}/static/images/minisasslogo1.png" alt="Company Logo" style="max-width: 200px; height: auto;">
         </div>
 
         <h2>Welcome to miniSASS!</h2>

--- a/django_project/minisass_authentication/templates/registration/contact_us.html
+++ b/django_project/minisass_authentication/templates/registration/contact_us.html
@@ -125,7 +125,7 @@ td.b .klaviyo-image-block{display:inline;vertical-align:middle;}
                                                             <tr>
                                                                 <td style="width:180px;">
                                                                     <!-- Image URL to be replaced by {{ domain }} -->
-                                                                    <img alt src="{{ domain }}/static/images/img_minisasslogo1.png" class="header-img" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" title width="123" height="auto">
+                                                                    <img alt src="https://{{ domain }}/static/images/minisasslogo1.png" class="header-img" style="border:0;display:block;outline:none;text-decoration:none;height:auto;width:100%;font-size:13px;" title width="123" height="auto">
                                                                 </td>
                                                             </tr>
                                                         </tbody>

--- a/django_project/minisass_authentication/templates/registration/password_reset_email.html
+++ b/django_project/minisass_authentication/templates/registration/password_reset_email.html
@@ -8,7 +8,7 @@
     <div style="max-width: 600px; margin: 20px auto; padding: 20px; background-color: #fff; border-radius: 8px; box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);">
         <!-- Logo -->
         <div style="text-align: center; margin-bottom: 20px;">
-            <img src="{{ logo }}" alt="Company Logo" style="max-width: 200px; height: auto;">
+            <img src="https://{{ domain }}/static/images/minisasslogo1.png" alt="Company Logo" style="max-width: 200px; height: auto;">
         </div>
 
         <h2>Password Reset Request</h2>

--- a/django_project/minisass_frontend/src/pages/MainPage/index.tsx
+++ b/django_project/minisass_frontend/src/pages/MainPage/index.tsx
@@ -21,6 +21,9 @@ const Home: React.FC = () => {
   const [currentIndex, setCurrentIndex] = useState(0);
   const [observations, setObservations] = useState([]);
   const ObservationsPropList = [];
+  const [activationComplete, setActivationComplete] = useState(false);
+  const [activationMessage, setActivationMessage] = useState('');
+
 
   const urlParams = new URLSearchParams(window.location.search);
 
@@ -71,6 +74,13 @@ const Home: React.FC = () => {
 
         const uidParam = urlParams.get('uid');
         const tokenParam = urlParams.get('token');
+
+        const activation_complete  = urlParams.get('activation_complete');
+
+        if (activation_complete) {
+          setActivationComplete(true);
+          setActivationMessage('Your registration is complete. Please proceed to log in')
+        }
     
         if (uidParam && tokenParam) {
           const pageName = `/password-reset?uid=${uidParam}&token=${tokenParam}`;
@@ -187,19 +197,6 @@ const Home: React.FC = () => {
     const closeUploadModal = () => {
       setIsUploadModalOpen(false);
     };
-
-    const location = useLocation();
-    const searchParams = new URLSearchParams(location.search);
-    const [activationComplete, setActivationComplete] = useState(false);
-    const [activationMessage, setActivationMessage] = useState('');
-
-    useEffect(() => {
-      const isActivationComplete = searchParams.get('activation_complete');
-      if (isActivationComplete) {
-        setActivationComplete(true);
-        setActivationMessage('Your registration is complete. Please proceed to log in')
-      }
-    }, [searchParams]);
 
     const closeActivationModal = () => {
       setActivationComplete(false)

--- a/django_project/minisass_frontend/src/pages/MainPage/index.tsx
+++ b/django_project/minisass_frontend/src/pages/MainPage/index.tsx
@@ -195,7 +195,7 @@ const Home: React.FC = () => {
 
     useEffect(() => {
       const isActivationComplete = searchParams.get('activation_complete');
-      if (isActivationComplete === 'true') {
+      if (isActivationComplete) {
         setActivationComplete(true);
         setActivationMessage('Your registration is complete. Please proceed to log in')
       }


### PR DESCRIPTION
![reg_complete](https://github.com/kartoza/miniSASS/assets/70011086/90f125b1-abc0-401f-a84e-4847dfcdd0ff)

Description 
when the user clicks on the activation link and their registration is completed a success message will be displayed.
I have also adjusted the path to the logo that was not showing in the email templates (reset password, activate account and contact us)

before the logo was missing like this 
![logo_missing](https://github.com/kartoza/miniSASS/assets/70011086/72268ed2-01fc-4964-ab5e-8821d486d719)

this has been resolved