### PR TITLE
Update add record form

### DIFF
--- a/django_project/minisass_frontend/src/components/CoordinatesInputForm/index.tsx
+++ b/django_project/minisass_frontend/src/components/CoordinatesInputForm/index.tsx
@@ -91,11 +91,9 @@ export default function CoordinatesInputForm(
           disabled={disabled}
           setLatitude={(value) => {
             setFieldValue('latitude', value);
-            handleMapClick(Number(value), Number(values.longitude))
           }}
           setLongitude={(value) => {
             setFieldValue('longitude', value);
-            handleMapClick(Number(values.latitude), Number(value))
           }}
         />
         :

--- a/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
+++ b/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
@@ -148,7 +148,13 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
   const [sites, setSitesList] = useState([]);
   const [enableSiteFields,setEnableSiteFields] = useState(true);
   const [isCreateSite, setIsCreateSite] = useState('createsite');
-  const [type, setType] = useState<string>('')
+  const [type, setType] = useState<string>('');
+  const [siteUserValues, setSiteUserValues] = useState({
+    rivercategory: 'rocky',
+    riverName: '',
+    siteName: '',
+    siteDescription: ''
+  })
 
   const positionRef = React.useRef<{ x: number; y: number }>({
     x: 0,

--- a/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
+++ b/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
@@ -9,6 +9,7 @@ import ScoreForm from "../../components/ScoreForm";
 import axios from "axios";
 import { globalVariables, formatDate } from "../../utils";
 import CoordinatesInputForm from "../CoordinatesInputForm";
+import Select from 'react-select';
 
 
 type DataInputFormProps = Omit<
@@ -202,6 +203,10 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
           const sitesList = response.data.map(site => ({
             label: site.site_name,
             value: site.gid.toString(),
+            rivercategory: site.river_cat,
+            siteName: site.site_name,
+            siteDescription: site.description,
+            riverName: site.river_name,
           }));
           setSitesList(sitesList);
       }
@@ -220,6 +225,42 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
   const formatDate = (date) => {
     const options = { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' };
     return date.toLocaleDateString(undefined, options);
+  };
+
+  // this will trigger select on map TODO
+  const handleSelectKnownSiteFromMapChange = (evt) => {
+    const newValue = evt.target.value;
+    
+    // Toggle between selected and unselected states
+    setType((prevType) => (prevType === newValue ? null : newValue));
+    
+    if (type === newValue) {
+      console.log('Radio button unselected');
+    } else {
+      console.log('Radio button selected');
+    }
+  };
+
+  
+  const customStyles = {
+    control: (styles, { isFocused }) => ({
+      ...styles,
+      borderRadius: '4px',
+      width: '300px',
+      borderColor: isFocused ? '#539987' : 'rgba(0, 0, 0, 0.23)',
+      marginLeft: '210px'
+      
+    }),
+    option: (styles, { isFocused }) => ({
+      ...styles,
+      backgroundColor: isFocused ? '#539987' : 'transparent',
+      color: isFocused ? 'white' : 'black',
+    }),
+    menu: (styles) => ({
+      ...styles,
+      width: '16.5vw',
+      marginLeft: '210px'
+    }),
   };
 
   return (
@@ -500,44 +541,58 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
 
                 {/* Additional field for select known site */}
                 {selectSiteMode === 'SELECT_KNOWN_SITE' && (
-                  <div>
-                    {/* known site */}
-                    <div className="flex flex-row h-[46px] md:h-auto items-start justify-start w-auto">
-                      <Text
-                        className="text-gray-800 text-lg tracking-[0.15px] w-auto"
-                        size="txtRalewayRomanRegular18"
+                  <>
+                    <RadioGroup
+                        value={type}
+                        onClick={handleSelectKnownSiteFromMapChange}
+                        row
                       >
-                        {`Sites:`}
-                      </Text>
-                      <div className="flex flex-row items-center justify-start w-[97%] sm:w-full">
-                        <Field as="select" name="selectedSite" className="!text-black-900_99 font-raleway text-base text-left"
-                            placeholderClassName="!text-black-900_99"
+                        <FormControlLabel value="MapSelection" control={<Radio />} label="Select On Map" />
+                      </RadioGroup>
+
+                    <div>
+                      {/* known site */}
+                      <div className="flex flex-row h-[46px] md:h-auto items-start justify-start w-auto">
+                        <Text
+                          className="text-gray-800 text-lg tracking-[0.15px] w-auto"
+                          size="txtRalewayRomanRegular18"
+                        >
+                          {`Sites:`}
+                        </Text>
+                        <div className="flex flex-row items-center justify-start w-[97%] sm:w-full">
+                          <Select
+                            name="selectedSite"
+                            options={sites}
+                            className="!text-black-900_99 font-raleway text-base text-left"
                             placeholder=""
-                            shape="round"
-                            color="black_900_3a"
-                            size="xs"
-                            variant="outline"
-                            style={{
-                              width: '300px',
-                              maxWidth: '300px',
-                              height: '40px',
-                              border: '1px solid rgba(0, 0, 0, 0.23)',
-                              borderRadius: '4px',
-                              padding: '8px 12px',
-                              marginLeft: '40%'
+                            isSearchable
+                            styles={customStyles}
+                            value={sites.find((option) => option.value === values.selectedSite)}
+                            onChange={(selectedOption) => {
+                              handleChange({ target: { name: 'selectedSite', value: selectedOption.value } });
+                              const selectedValue = selectedOption.value;
+                              if (selectedValue === 'none') {
+                                setIsInputDisabled(false);
+                                setFieldValue('riverName', '');
+                                setFieldValue('siteName', '');
+                                setFieldValue('rivercategory', 'Rocky');
+                                setFieldValue('siteDescription', '');
+                              } else {
+                                setIsInputDisabled(true);
+                                const selectedSite = sites.find((site) => site.value === selectedValue);
+                                if (selectedSite) {
+                                  setFieldValue('riverName', selectedSite.riverName);
+                                  setFieldValue('siteName', selectedSite.siteName);
+                                  setFieldValue('rivercategory', selectedSite.riverCategory);
+                                  setFieldValue('siteDescription', selectedSite.siteDescription);
+                                }
+                              }
                             }}
-                          value={values.selectedSite}
-                          onChange={handleChange}
-                          >
-                          {sites.map((option) => (
-                            <option key={option.value} value={option.value} selected={option.value === values.selectedSite}>
-                              {option.label}
-                            </option>
-                          ))}
-                        </Field>
+                          />
+                        </div>
                       </div>
                     </div>
-                  </div>
+                  </>
                 )}
 
                 {/* Additional fields for longitude and latitude */}

--- a/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
+++ b/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
@@ -847,13 +847,13 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
                           size="xs"
                           variant="outline"
                           style={{
-                            width: '215px',
-                            maxWidth: '215px',
+                            width: '219px',
+                            maxWidth: '219px',
                             height: '40px',
                             border: '1px solid rgba(0, 0, 0, 0.23)',
                             borderRadius: '4px',
                             padding: '8px 12px',
-                            marginRight: '-44px'
+                            marginRight: '-43px'
                           }}
                           value={values.dissolvedoxygenOne}
                           onChange={handleChange}
@@ -866,13 +866,14 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
                             size="xs"
                             variant="outline"
                             style={{
-                              width: '120px',
-                              maxWidth: '120px',
+                              width: '85px',
+                              maxWidth: '85px',
                               height: '40px',
                               border: '1px solid rgba(0, 0, 0, 0.23)',
                               borderRadius: '4px',
                               padding: '8px 12px',
-                              marginLeft: '17%'
+                              marginRight: '-20px',
+                              marginLeft: '50px'
                             }}
                           value={values.dissolvedoxygenOneUnit}
                           onChange={handleChange}
@@ -910,13 +911,13 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
                           size="xs"
                           variant="outline"
                           style={{
-                            width: '215px',
-                            maxWidth: '215px',
+                            width: '211px',
+                            maxWidth: '211px',
                             height: '40px',
                             border: '1px solid rgba(0, 0, 0, 0.23)',
                             borderRadius: '4px',
                             padding: '8px 12px',
-                            marginRight: '-44px'
+                            marginRight: '-35px'
                           }}
                           value={values.electricalconduOne}
                           onChange={handleChange}
@@ -929,13 +930,14 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
                             size="xs"
                             variant="outline"
                             style={{
-                              width: '120px',
-                              maxWidth: '120px',
+                              width: '85px',
+                              maxWidth: '85px',
                               height: '40px',
                               border: '1px solid rgba(0, 0, 0, 0.23)',
                               borderRadius: '4px',
                               padding: '8px 12px',
-                              marginLeft: '17%'
+                              marginRight: '-11px',
+                              marginLeft: '43px'
                             }}
                           value={values.electricalconduOneUnit}
                           onChange={handleChange}

--- a/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
+++ b/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
@@ -144,7 +144,13 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
   const [selectSiteMode, setSelectSiteMode] = useState<SiteSelectionMode | undefined>();
   const [sites, setSitesList] = useState([]);
   const [isInputDisabled,setIsInputDisabled] = useState(false);
-  const [type, setType] = useState<string>('')
+  const [type, setType] = useState<string>('');
+  const [siteUserValues, setSiteUserValues] = useState({
+    rivercategory: 'rocky',
+    riverName: '',
+    siteName: '',
+    siteDescription: ''
+  })
 
   const positionRef = React.useRef<{ x: number; y: number }>({
     x: 0,
@@ -363,6 +369,10 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
                     value={values.riverName}
                     onChange={(e) => {
                       handleChange(e);
+                      setSiteUserValues((prevValues) => ({
+                        ...prevValues,
+                        riverName: e.target.value
+                      }));
                     }}
                     disabled={isInputDisabled ? true : false}
                   />
@@ -396,7 +406,13 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
                       marginBottom: '4.5%'
                     }}
                     value={values.siteName}
-                    onChange={handleChange}
+                    onChange={(e) => {
+                      handleChange(e);
+                      setSiteUserValues((prevValues) => ({
+                        ...prevValues,
+                        siteName: e.target.value
+                      }));
+                    }}
                     disabled={isInputDisabled ? true : false}
                   />
                 </div>
@@ -424,7 +440,13 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
                         }}
                         placeholder="e.g. downstream of industry."
                         value={values.siteDescription}
-                        onChange={handleChange}
+                        onChange={(e) => {
+                          handleChange(e);
+                          setSiteUserValues((prevValues) => ({
+                            ...prevValues,
+                            siteDescription: e.target.value
+                          }));
+                        }}
                         disabled={isInputDisabled ? true : false}
                       />
                 </div>
@@ -578,10 +600,10 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
                               const selectedValue = selectedOption.value;
                               if (selectedValue === 'none') {
                                 setIsInputDisabled(false);
-                                setFieldValue('riverName', '');
-                                setFieldValue('siteName', '');
-                                setFieldValue('rivercategory', 'Rocky');
-                                setFieldValue('siteDescription', '');
+                                setFieldValue('riverName', siteUserValues.riverName);
+                                setFieldValue('siteName', siteUserValues.siteName);
+                                setFieldValue('rivercategory', siteUserValues.rivercategory);
+                                setFieldValue('siteDescription', siteUserValues.siteDescription);
                               } else {
                                 setIsInputDisabled(true);
                                 const selectedSite = sites.find((site) => site.value === selectedValue);

--- a/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
+++ b/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
@@ -143,6 +143,8 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
   const [selectSiteMode, setSelectSiteMode] = useState<SiteSelectionMode | undefined>();
   const [sites, setSitesList] = useState([]);
+  const [isInputDisabled,setIsInputDisabled] = useState(false);
+  const [type, setType] = useState<string>('')
 
   const positionRef = React.useRef<{ x: number; y: number }>({
     x: 0,
@@ -362,6 +364,7 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
                     onChange={(e) => {
                       handleChange(e);
                     }}
+                    disabled={isInputDisabled ? true : false}
                   />
                 </div>
 
@@ -394,6 +397,7 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
                     }}
                     value={values.siteName}
                     onChange={handleChange}
+                    disabled={isInputDisabled ? true : false}
                   />
                 </div>
 
@@ -421,6 +425,7 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
                         placeholder="e.g. downstream of industry."
                         value={values.siteDescription}
                         onChange={handleChange}
+                        disabled={isInputDisabled ? true : false}
                       />
                 </div>
 
@@ -481,7 +486,7 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
                           padding: '8px 12px',
                           marginBottom: '2%'
                         }}
-
+                        disabled={isInputDisabled ? true : false}
                       >
                       {inputOptionsList.map((option) => (
                         <option key={option.value} value={option.value} selected={option.value === values.rivercategory}>

--- a/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
+++ b/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
@@ -395,14 +395,25 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
                               value={sites.find((option) => option.value === values.selectedSite)}
                               onChange={(selectedOption) => {
                                 handleChange({ target: { name: 'selectedSite', value: selectedOption.value } });
+                              
                                 const selectedValue = selectedOption.value;
-                                const selectedSite = sites.find((site) => site.value === selectedValue);
-                                if (selectedSite) {
-                                  setIsCreateSite('useexistingsite')
-                                  setFieldValue('riverName', selectedSite.riverName);
-                                  setFieldValue('siteName', selectedSite.siteName);
-                                  setFieldValue('rivercategory', selectedSite.riverCategory);
-                                  setFieldValue('siteDescription', selectedSite.siteDescription);
+                              
+                                if (selectedValue === 'none') {
+                                  // Clear variables when "None" is selected
+                                  setFieldValue('riverName', '');
+                                  setFieldValue('siteName', '');
+                                  setFieldValue('rivercategory', '');
+                                  setFieldValue('siteDescription', '');
+                                  setIsCreateSite('useexistingsite');
+                                } else {
+                                  const selectedSite = sites.find((site) => site.value === selectedValue);
+                                  if (selectedSite) {
+                                    setIsCreateSite('useexistingsite');
+                                    setFieldValue('riverName', selectedSite.riverName);
+                                    setFieldValue('siteName', selectedSite.siteName);
+                                    setFieldValue('rivercategory', selectedSite.riverCategory);
+                                    setFieldValue('siteDescription', selectedSite.siteDescription);
+                                  }
                                 }
                               }}
                             />

--- a/django_project/minisass_frontend/src/components/Map/Map.tsx
+++ b/django_project/minisass_frontend/src/components/Map/Map.tsx
@@ -20,6 +20,7 @@ interface Interface {
   overlayLayers: layerConfiguration[],
   handleSelect: (latitude: number, longitude: number) => void;
   selectingOnMap: boolean;
+  resetMap: boolean;
   selectedCoordinates: {latitude: number, longitude: number};
   idxActive: number;
   setIdxActive: React.Dispatch<React.SetStateAction<number>>;
@@ -334,6 +335,21 @@ export const Map = forwardRef((props: Interface, ref) => {
         removeClickEventListener();
       };
     }, [props.handleSelect, props.selectingOnMap,props.selectedCoordinates]);
+
+    useEffect(() => {
+      if (props.resetMap === true) {
+        let mapInstance = map;
+  
+        if (mapInstance) {
+          mapInstance.flyTo({
+            center: [initialMapConfig.center[0], initialMapConfig.center[1]],
+            zoom: initialMapConfig.zoom,
+            essential: true,
+          });
+        }
+        props.resetCoordinates()
+      }
+    }, [props.resetMap]);
 
     return <div id="map" className="w-full h-full bg-slate-200">
       {

--- a/django_project/minisass_frontend/src/components/Map/Map.tsx
+++ b/django_project/minisass_frontend/src/components/Map/Map.tsx
@@ -34,6 +34,15 @@ const HIGHLIGHT_CIRCLE_ID = HIGHLIGHT_ID + '-circle'
 const HIGHLIGHT_LINE_ID = HIGHLIGHT_ID + '-line'
 const HIGHLIGHT_POLYGON_ID = HIGHLIGHT_ID + '-polygon'
 
+const initialMapConfig = {
+  container: 'map',
+  style: [],
+  center: [24.679864950000024, -28.671882886975247],
+  zoom: 5.3695883239884745,
+  attributionControl: false,
+  maxZoom: 17,
+};
+
 /**
  * Map component using maplibre
  * @param props

--- a/django_project/minisass_frontend/src/components/ScoreForm/index.tsx
+++ b/django_project/minisass_frontend/src/components/ScoreForm/index.tsx
@@ -5,6 +5,9 @@ import UploadModal from "../../components/UploadFormModal";
 import ManageImagesModal from "../../components/ManageImagesModal";
 import { globalVariables } from "../../utils";
 import Modal from 'react-modal';
+import LinearProgress from '@mui/material/LinearProgress';
+import Typography from '@mui/material/Typography';
+
 
 
 interface ScoreFormProps {
@@ -42,6 +45,7 @@ const ScoreForm: FC<ScoreFormProps> = ({ onCancel, additionalData, setSidebarOpe
   const [averageScore, setAverageScore] = useState(0);
   const [openImagePestId, setOpenImagePestId] = useState(0);
   const [pestImages, setPestImages] = useState({});
+  const [isSavingData, setIsSavingData] = useState(false);
 
   const closeSuccessModal = () => {
     setIsSuccessModalOpen(false);
@@ -90,6 +94,7 @@ const ScoreForm: FC<ScoreFormProps> = ({ onCancel, additionalData, setSidebarOpe
 
   // Function to log the state of checkboxes
   const handleSave = async () => {
+    setIsSavingData(true)
     try {
       // Create an object with the data to be saved
       const observationsData = {
@@ -123,9 +128,11 @@ const ScoreForm: FC<ScoreFormProps> = ({ onCancel, additionalData, setSidebarOpe
       );
 
       if(response.status == 200){
+        setIsSavingData(false)
         setIsSuccessModalOpen(true);
       }
     } catch (error) {
+      setIsSavingData(false)
       setErrorMessage(error.message);
       setIsErrorModalOpen(true);
     }
@@ -185,6 +192,10 @@ const ScoreForm: FC<ScoreFormProps> = ({ onCancel, additionalData, setSidebarOpe
           overflowX: 'auto'
         }}
       >
+        {isSavingData ? (
+          <LinearProgress color="success" />
+        ) :
+        (
 
         <div className=" flex flex-col gap-3  items-start justify-start p-3 md:px-5 rounded-bl-[10px] rounded-br-[10px] rounded-tr-[10px] shadow-bs w-[568px] sm:w-full">
           <div
@@ -353,6 +364,7 @@ const ScoreForm: FC<ScoreFormProps> = ({ onCancel, additionalData, setSidebarOpe
           </div>
 
         </div>
+      )}
         {/* Success Modal */}
         <Modal
           isOpen={isSuccessModalOpen}
@@ -375,25 +387,34 @@ const ScoreForm: FC<ScoreFormProps> = ({ onCancel, additionalData, setSidebarOpe
         >
           {isSuccessModalOpen && (
             <div>
-               <Img
-                    className="h-6 w-6 common-pointer"
-                    src={`${globalVariables.staticPath}img_icbaselineclose.svg`}
-                    alt="close"
-                    onClick={closeSuccessModal}
-                    style={{ marginLeft: '340px'}}
-                  />
-              <div
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  marginLeft: '80px',
-                }}
-              >
-                <Text size="txtRalewayBold18" className="text-green-500">
-                Your data was successfully captured.
-              </Text>
-              </div>
+              <h3
+                  style={{
+                    fontFamily: 'Raleway',
+                    fontStyle: 'normal',
+                    fontWeight: 700,
+                    alignItems: 'flex-start',
+                    fontSize: '24px',
+                    lineHeight: '136.4%',
+                    color: '#539987',
+                  }}
+                >
+                  Observation Saved.
+                </h3>
+                <br />
+              <Typography>
+                The record was saved successfully.
+              </Typography>
+
+              <Button
+                  className="cursor-pointer rounded-bl-[10px] rounded-br-[10px] rounded-tr-[10px] text-center text-lg tracking-[0.81px] w-[156px]"
+                  color="blue_gray_500"
+                  size="xs"
+                  variant="fill"
+                  style={{ marginLeft: "55%" }}
+                  onClick={closeSuccessModal}
+                >
+                  Ok
+                </Button>
             </div>
           )}
         </Modal>
@@ -420,28 +441,39 @@ const ScoreForm: FC<ScoreFormProps> = ({ onCancel, additionalData, setSidebarOpe
         >
           {isErrorModalOpen && (
             <div>
-               <Img
-                  className="h-6 w-6 common-pointer"
-                  src={`${globalVariables.staticPath}img_icbaselineclose.svg`}
-                  alt="close"
+              <h3
+                  style={{
+                    fontFamily: 'Raleway',
+                    fontStyle: 'normal',
+                    fontWeight: 700,
+                    alignItems: 'flex-start',
+                    fontSize: '24px',
+                    lineHeight: '136.4%',
+                    color: '#d00501',
+                  }}
+                >
+                  Error.
+              </h3>
+                
+              <br />
+            <Text size="txtRalewayBold18" className="text-red-500">
+              {errorMessage}
+            </Text>
+            <Button
+                  className="!text-white-A700 cursor-pointer font-raleway min-w-[105px] text-center text-lg tracking-[0.81px]"
+                  shape="round"
+                  color="red_500"
+                  size="xs"
+                  variant="fill"
+                  style={{ marginLeft: "70%" }}
                   onClick={closeErrorModal}
-                  style={{ marginLeft: '340px'}}
-                />
-              <div
-                style={{
-                  display: 'flex',
-                  justifyContent: 'space-between',
-                  alignItems: 'center',
-                  marginLeft: '80px',
-                }}
-              >
-                <Text size="txtRalewayBold18" className="text-red-500">
-                    {errorMessage}
-                  </Text>
+                >
+                  Close
+                </Button>
               </div>
-            </div>
           )}
         </Modal>
+        
         <ManageImagesModal
           title={manageImagesModalData.groups}
           isOpen={isManageImagesModalOpen}

--- a/django_project/minisass_frontend/src/components/Sidebar/index.tsx
+++ b/django_project/minisass_frontend/src/components/Sidebar/index.tsx
@@ -28,7 +28,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   return (
     <div
       className={`absolute ${
-        isOpen ? "right-0" : "-right-full"
+        isOpen ? "right-[10px]" : "-right-full"
       } bg-white-A700 flex flex-col  items-start justify-center py-5 rounded-bl-[10px] rounded-br-[10px] rounded-tr-[10px] top-[0%] sm:top-[25px] w-auto transition-all duration-300`}
     >
       {isObservationDetails ? (

--- a/django_project/minisass_frontend/src/components/Sidebar/index.tsx
+++ b/django_project/minisass_frontend/src/components/Sidebar/index.tsx
@@ -13,6 +13,7 @@ interface SidebarProps {
   handleMapClick: (longitude: number, latitude: number) => void;
   selectingOnMap: boolean;
   selectedCoordinates: {longitude: number, latitude: number};
+  resetMap: () => void;
 }
 
 const Sidebar: React.FC<SidebarProps> = ({ 
@@ -23,7 +24,9 @@ const Sidebar: React.FC<SidebarProps> = ({
   toggleMapSelection, 
   handleMapClick,
   selectingOnMap,
-  selectedCoordinates
+  selectedCoordinates,
+  resetMap
+  
 }) => {
   return (
     <div
@@ -49,6 +52,7 @@ const Sidebar: React.FC<SidebarProps> = ({
           handleMapClick={handleMapClick}
           selectingOnMap={selectingOnMap}
           selectedCoordinates={selectedCoordinates}
+          resetMap={resetMap}
         />
       )}
       

--- a/django_project/minisass_frontend/src/components/Sidebar/index.tsx
+++ b/django_project/minisass_frontend/src/components/Sidebar/index.tsx
@@ -30,6 +30,9 @@ const Sidebar: React.FC<SidebarProps> = ({
       className={`absolute ${
         isOpen ? "right-[10px]" : "-right-full"
       } bg-white-A700 flex flex-col  items-start justify-center py-5 rounded-bl-[10px] rounded-br-[10px] rounded-tr-[10px] top-[0%] sm:top-[25px] w-auto transition-all duration-300`}
+      style={{
+        marginTop: '0.2%'
+      }}
     >
       {isObservationDetails ? (
         <ObservationDetails 

--- a/django_project/minisass_frontend/src/pages/Map/index.tsx
+++ b/django_project/minisass_frontend/src/pages/Map/index.tsx
@@ -83,6 +83,13 @@ const MapPage: React.FC = () => {
     setSelectingOnMap((prev) => !prev);
   };
 
+  const [resetMapToDefault, setResetMap] = useState(false);
+
+  function resetMap(): void {
+    setSelectedCoordinates({latitude: null, longitude: null})
+    setResetMap(true)
+  }
+
   return (
     <>
       <div className="bg-white-A700 flex flex-col font-raleway items-center justify-start mx-auto w-full h-screen">
@@ -151,6 +158,7 @@ const MapPage: React.FC = () => {
                 handleSelect={handleMapClick} 
                 selectingOnMap={selectingOnMap}
                 selectedCoordinates={selectedCoordinates}
+                resetMap={resetMapToDefault}
                 idxActive={idxActive}
                 setIdxActive={setIdxActive}
               />
@@ -164,6 +172,7 @@ const MapPage: React.FC = () => {
                 selectingOnMap={selectingOnMap}
                 handleMapClick={handleMapClick}
                 selectedCoordinates={selectedCoordinates}
+                resetMap={resetMap}
               />
             </div>
           </div>


### PR DESCRIPTION
https://github.com/kartoza/miniSASS/assets/70011086/dc6c2505-5f54-4fab-9d9c-cf5917adbe76

Description:

the select site field is now searchable 
selecting a site will cause the input fields for site data to be disabled
at the same time they will be populated with the site values the user would have selected 
this helps on the ui side the user will know they can't edit or update an existing site but the information presented is just make them know they're saving data in the right place 

other adjustments 
indented the sidebar to the left to make the form scroll accessible ...also added a top margin
![data_input_form](https://github.com/kartoza/miniSASS/assets/70011086/038e55ac-75de-47bd-baf3-1fa326b59161)

made the fields width equal 
![fields_width](https://github.com/kartoza/miniSASS/assets/70011086/64d9f54b-38ca-4bfd-b020-aa0fa71025ac)


@NyakudyaA 

https://github.com/kartoza/miniSASS/assets/70011086/c82ba600-e4a3-4ab1-8b8b-49b32f57af8f

the add record form when opened will be set on create new site by default ...if the user chooses use existing site the fields and tools for create new site will be disabled 

The pr is split TODO
- [ ] the other one will implement the select site on map