### PR TITLE
patch: declare tabs data as an array

### DIFF
--- a/django_project/minisass_frontend/src/components/ObservationDetails/index.tsx
+++ b/django_project/minisass_frontend/src/components/ObservationDetails/index.tsx
@@ -94,7 +94,7 @@ const ObservationDetails: React.FC<ObservationDetailsProps> = ({
   const [observations, setObservations] = useState([]);
   const [activeTabIndex, setActiveTabIndex] = useState<number>(0);
   const [siteDetails, setSiteDetails] = useState({});
-  const [tabsData, setTabsData] = useState({});
+  const [tabsData, setTabsData] = useState([]);
 
   const updateScoreDisplay = (score) => {
     if (parseFloat(score) < 6) {


### PR DESCRIPTION
Description:

this should prevent the map error allowing the observation panel to open
