### PR TITLE
patch: prevent opening observation details if site observations is null

### DIFF
--- a/django_project/minisass_frontend/src/pages/Map/index.tsx
+++ b/django_project/minisass_frontend/src/pages/Map/index.tsx
@@ -87,9 +87,12 @@ const MapPage: React.FC = () => {
   const [siteWithObservations, setSiteWithObservations] = useState({site:{}, observations: []});
 
   const openObservationForm = (siteWithObservations: {site: {}, observations: []}) => {
-    setSiteWithObservations(siteWithObservations)
-    setIsObservationDetails(true)
-    setSidebarOpen((prev) => !prev);
+    
+    if(siteWithObservations.observations.length > 0){
+      setSiteWithObservations(siteWithObservations)
+      setIsObservationDetails(true)
+      setSidebarOpen((prev) => !prev);
+    }
   }
 
   const [resetMapToDefault, setResetMap] = useState(false);


### PR DESCRIPTION
Description:

the observation sidebar panel should only be opened when the site has observations