### PR TITLE
patch: add missing prop

### DIFF
--- a/django_project/minisass_frontend/src/pages/Map/index.tsx
+++ b/django_project/minisass_frontend/src/pages/Map/index.tsx
@@ -188,6 +188,7 @@ const MapPage: React.FC = () => {
                 idxActive={idxActive}
                 setIdxActive={setIdxActive}
                 openObservationForm={openObservationForm}
+                setSiteDetails={setSiteDetails}
                 resetMap={resetMapToDefault}
               />
               {/* Sidebar */}


### PR DESCRIPTION
Description 

the set site details prop was missing causing the set sitedetails undefined error in maps causing the sidebar panel to isntantly crash . This has been resolved