### PR TITLE
patch: add a horizontal scroll to the tabs

### DIFF
--- a/django_project/minisass_frontend/src/components/TabbedContent/index.tsx
+++ b/django_project/minisass_frontend/src/components/TabbedContent/index.tsx
@@ -7,7 +7,7 @@ const TabbedContent = ({ tabsData, activeTabIndex, onTabChange }) => {
 
   return (
     <div className="flex flex-col items-start justify-start w-full">
-      <div className="flex gap-5">
+      <div className="flex gap-5 overflow-x-auto">
         {tabsData.map((tab, index) => (
           <button
             key={tab.id}


### PR DESCRIPTION
Description

The date tabs for on observation details did not have a horizontal scroll. This has been added