### PR TITLE
patch: add a horizontal scroll to the observation tabs

### DIFF
--- a/django_project/minisass_frontend/src/components/TabbedContent/index.tsx
+++ b/django_project/minisass_frontend/src/components/TabbedContent/index.tsx
@@ -6,7 +6,7 @@ const TabbedContent = ({ tabsData, activeTabIndex, onTabChange }) => {
   };
 
   return (
-    <div className="flex flex-col items-start justify-start w-[28vw]" style={{overflowX: 'auto', overflowY: 'hidden'}}>
+    <div className="flex flex-col items-start justify-start w-[38vw]" style={{overflowX: 'auto', overflowY: 'hidden'}}>
       <div className="flex gap-5">
         {tabsData.map((tab, index) => (
           <button

--- a/django_project/minisass_frontend/src/components/TabbedContent/index.tsx
+++ b/django_project/minisass_frontend/src/components/TabbedContent/index.tsx
@@ -6,24 +6,26 @@ const TabbedContent = ({ tabsData, activeTabIndex, onTabChange }) => {
   };
 
   return (
-    <div className="flex flex-col items-start justify-start w-full">
-      <div className="flex gap-5">
-        {tabsData.map((tab, index) => (
-          <button
-            key={tab.id}
-            className={`cursor-pointer min-w-[126px] text-base text-center focus:outline-none ${activeTabIndex === index ? 'border-b-4 border-blue-900 text-blue-900' : ''}`}
-            onClick={() => handleTabChange(index)}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
-      <div className="w-full">
-        {tabsData.map((tab, index) => (
-          <div key={`content_${tab.id}`} style={{ display: activeTabIndex === index ? 'block' : 'none' }}>
-            {tab.content}
-          </div>
-        ))}
+    <div className="w-full overflow-x-auto">
+      <div className="flex flex-col items-start justify-start">
+        <div className="flex gap-5">
+          {tabsData.map((tab, index) => (
+            <button
+              key={tab.id}
+              className={`cursor-pointer min-w-[126px] text-base text-center focus:outline-none ${activeTabIndex === index ? 'border-b-4 border-blue-900 text-blue-900' : ''}`}
+              onClick={() => handleTabChange(index)}
+            >
+              {tab.label}
+            </button>
+          ))}
+        </div>
+        <div className="w-full">
+          {tabsData.map((tab, index) => (
+            <div key={`content_${tab.id}`} style={{ display: activeTabIndex === index ? 'block' : 'none' }}>
+              {tab.content}
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );

--- a/django_project/minisass_frontend/src/components/TabbedContent/index.tsx
+++ b/django_project/minisass_frontend/src/components/TabbedContent/index.tsx
@@ -1,31 +1,31 @@
 import React, { useState } from 'react';
 
-const TabbedContent = ({ tabsData, activeTabIndex, onTabChange }) => {
-  const handleTabChange = (tabIndex) => {
-    onTabChange(tabIndex);
+const TabbedContent = ({ tabsData }) => {
+  const [selectedTab, setSelectedTab] = useState(tabsData[0].id);
+
+  const handleTabChange = (tabId) => {
+    setSelectedTab(tabId);
   };
 
   return (
-    <div className="w-full overflow-x-auto">
-      <div className="flex flex-col items-start justify-start">
-        <div className="flex gap-5">
-          {tabsData.map((tab, index) => (
-            <button
-              key={tab.id}
-              className={`cursor-pointer min-w-[126px] text-base text-center focus:outline-none ${activeTabIndex === index ? 'border-b-4 border-blue-900 text-blue-900' : ''}`}
-              onClick={() => handleTabChange(index)}
-            >
-              {tab.label}
-            </button>
-          ))}
-        </div>
-        <div className="w-full">
-          {tabsData.map((tab, index) => (
-            <div key={`content_${tab.id}`} style={{ display: activeTabIndex === index ? 'block' : 'none' }}>
-              {tab.content}
-            </div>
-          ))}
-        </div>
+    <div className="flex flex-col items-start justify-start w-[28vw]" style={{overflowX: 'auto', overflowY: 'hidden'}}>
+      <div className="flex gap-5">
+        {tabsData.map((tab) => (
+          <button
+            key={tab.id}
+            className={`cursor-pointer min-w-[126px] text-base text-center ${selectedTab === tab.id && 'active'}`}
+            onClick={() => handleTabChange(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div className="w-full">
+        {tabsData.map((tab) => (
+          <div key={`content_${tab.id}`} style={{ display: selectedTab === tab.id ? 'block' : 'none' }}>
+            {tab.content}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/django_project/minisass_frontend/src/components/TabbedContent/index.tsx
+++ b/django_project/minisass_frontend/src/components/TabbedContent/index.tsx
@@ -1,28 +1,26 @@
 import React, { useState } from 'react';
 
-const TabbedContent = ({ tabsData }) => {
-  const [selectedTab, setSelectedTab] = useState(tabsData[0].id);
-
-  const handleTabChange = (tabId) => {
-    setSelectedTab(tabId);
+const TabbedContent = ({ tabsData, activeTabIndex, onTabChange }) => {
+  const handleTabChange = (tabIndex) => {
+    onTabChange(tabIndex);
   };
 
   return (
     <div className="flex flex-col items-start justify-start w-[28vw]" style={{overflowX: 'auto', overflowY: 'hidden'}}>
       <div className="flex gap-5">
-        {tabsData.map((tab) => (
+        {tabsData.map((tab, index) => (
           <button
             key={tab.id}
-            className={`cursor-pointer min-w-[126px] text-base text-center ${selectedTab === tab.id && 'active'}`}
-            onClick={() => handleTabChange(tab.id)}
+            className={`cursor-pointer min-w-[126px] text-base text-center focus:outline-none ${activeTabIndex === index ? 'border-b-4 border-blue-900 text-blue-900' : ''}`}
+            onClick={() => handleTabChange(index)}
           >
             {tab.label}
           </button>
         ))}
       </div>
       <div className="w-full">
-        {tabsData.map((tab) => (
-          <div key={`content_${tab.id}`} style={{ display: selectedTab === tab.id ? 'block' : 'none' }}>
+        {tabsData.map((tab, index) => (
+          <div key={`content_${tab.id}`} style={{ display: activeTabIndex === index ? 'block' : 'none' }}>
             {tab.content}
           </div>
         ))}


### PR DESCRIPTION
the intent of this is that if the tabs for a certain site happen to exceed the available minimum width on the observation details form instead of stretching the form (current behaviour) , a horizontal scroll will be added then the user can scroll to see the other tabs