### PR TITLE
patch: set selected site value

### DIFF
--- a/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
+++ b/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
@@ -536,7 +536,7 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
                                       setFieldValue('selectedSite', selectedSite);
                                       setFieldValue('riverName', selectedSite.riverName);
                                       setFieldValue('siteName', selectedSite.siteName);
-                                      setFieldValue('rivercategory', selectedSite.riverCategory);
+                                      setFieldValue('rivercategory', selectedSite.rivercategory);
                                       setFieldValue('siteDescription', selectedSite.siteDescription);
                                     }
                                   }
@@ -746,7 +746,7 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
                           key={option.value} 
                           value={(() => {
                             const siteRivercategory = props.siteDetails?.rivercategory;
-                            const selectedValue = siteRivercategory ? siteRivercategory : values.rivercategory;
+                            const selectedValue = siteRivercategory ? siteRivercategory : option.value;
                             return selectedValue;
                           })()}
                           selected={option.value === values.rivercategory}

--- a/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
+++ b/django_project/minisass_frontend/src/components/DataInputForm/index.tsx
@@ -523,6 +523,7 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
                                 
                                   if (selectedValue === 'none') {
                                     // Clear variables when "None" is selected
+                                    setFieldValue('selectedSite', 'none');
                                     setFieldValue('riverName', '');
                                     setFieldValue('siteName', '');
                                     setFieldValue('rivercategory', '');
@@ -532,6 +533,7 @@ const DataInputForm: React.FC<DataInputFormProps> = (props) => {
                                     const selectedSite = sites.find((site) => site.value === selectedValue);
                                     if (selectedSite) {
                                       setIsCreateSite('useexistingsite');
+                                      setFieldValue('selectedSite', selectedSite);
                                       setFieldValue('riverName', selectedSite.riverName);
                                       setFieldValue('siteName', selectedSite.siteName);
                                       setFieldValue('rivercategory', selectedSite.riverCategory);


### PR DESCRIPTION
Description

with this when select site on map is selected and the user clicks an existing site all the field values for site details will be populated including the sites field which was currently remaining empty