### PR TITLE
patch: retry fetch when 404 is returned

### DIFF
--- a/django_project/minisass_frontend/src/components/ObservationDetails/index.tsx
+++ b/django_project/minisass_frontend/src/components/ObservationDetails/index.tsx
@@ -131,7 +131,7 @@ const ObservationDetails: React.FC<ObservationDetailsProps> = ({
     );
   }
 
-  const fetchObservation = async () => {
+  const fetchObservation = async (retryCount = 0) => {
     try {
       const response = await axios.get(`${GET_OBSERVATION}`);
       
@@ -146,7 +146,13 @@ const ObservationDetails: React.FC<ObservationDetailsProps> = ({
 
         updateScoreDisplay(response.data.score);
 
-      } else { }
+      } else {
+        if (retryCount < 3) {
+          setTimeout(() => {
+            fetchObservation(retryCount+1);
+          }, 3000);
+        }
+      }
     } catch (error) {
       console.log(error.message)
      }


### PR DESCRIPTION
Description

when a user clicks on view details of an observation from the home page sometimes the loader remains . This is due to the request to fetch the observation having returned a 404 not found error which is a result of a lot of network requests occurring when the map page is loaded for the first time ...so this solution is an attempt to lazily load the observation as it retries to fetch it after 3 seconds 