### PR TITLE
patch: prevent observation panel from closing

### DIFF
--- a/django_project/minisass_frontend/src/components/TabbedContent/index.tsx
+++ b/django_project/minisass_frontend/src/components/TabbedContent/index.tsx
@@ -1,6 +1,9 @@
 import React, { useState } from 'react';
 
 const TabbedContent = ({ tabsData, activeTabIndex, onTabChange }) => {
+  // Sort tabsData by the date in descending order
+  const sortedTabsData = [...tabsData].sort((a, b) => new Date(b.label) - new Date(a.label));
+
   const handleTabChange = (tabIndex) => {
     onTabChange(tabIndex);
   };
@@ -8,7 +11,7 @@ const TabbedContent = ({ tabsData, activeTabIndex, onTabChange }) => {
   return (
     <div className="flex flex-col items-start justify-start w-full">
       <div className="flex gap-5">
-        {tabsData.map((tab, index) => (
+        {sortedTabsData.map((tab, index) => (
           <button
             key={tab.id}
             className={`cursor-pointer min-w-[126px] text-base text-center focus:outline-none ${activeTabIndex === index ? 'border-b-4 border-blue-900 text-blue-900' : ''}`}
@@ -19,7 +22,7 @@ const TabbedContent = ({ tabsData, activeTabIndex, onTabChange }) => {
         ))}
       </div>
       <div className="w-full">
-        {tabsData.map((tab, index) => (
+        {sortedTabsData.map((tab, index) => (
           <div key={`content_${tab.id}`} style={{ display: activeTabIndex === index ? 'block' : 'none' }}>
             {tab.content}
           </div>

--- a/django_project/minisass_frontend/src/pages/Map/index.tsx
+++ b/django_project/minisass_frontend/src/pages/Map/index.tsx
@@ -101,7 +101,7 @@ const MapPage: React.FC = () => {
     if(siteWithObservations.observations.length > 0 && !isSelectSiteOnMap){
       setSiteWithObservations(siteWithObservations)
       setIsObservationDetails(true)
-      setSidebarOpen((prev) => !prev);
+      setSidebarOpen(true);
       setSelectedCoordinates({
         latitude: siteWithObservations.site.latitude,
         longitude: siteWithObservations.site.longitude


### PR DESCRIPTION
This will prevent the observation panel from closing when another observation is clicked 

it will also sort the observations in descending order ,showing the most recent one first

for issues:
https://github.com/kartoza/miniSASS/issues/634
https://github.com/kartoza/miniSASS/issues/657


https://github.com/kartoza/miniSASS/assets/70011086/d52fe78c-9815-4a9c-9b83-527a50ecc47f

