### PR TITLE
Fix/ai patch

### DIFF
--- a/django_project/minisass_frontend/src/components/ScoreForm/index.tsx
+++ b/django_project/minisass_frontend/src/components/ScoreForm/index.tsx
@@ -291,6 +291,7 @@ const ScoreForm: React.FC<ScoreFormProps> = ({ onCancel, additionalData, setSide
             );
         
             if(response.status == 200){
+              console.log('response data: ',response.data)
               setObservationId(response.data.observation_id)
               setSiteId(response.data.site_id)
               // setImageAiPrediction(response.data.classification_results[0])

--- a/django_project/monitor/observation_views.py
+++ b/django_project/monitor/observation_views.py
@@ -85,6 +85,7 @@ def retrieve_file_from_minio(file_name):
 			s3_client = get_s3_client()
 			try:
 				s3_client.download_file(settings.MINIO_AI_BUCKET, file_name, file_path)
+				return file_path
 			except botocore.exceptions.ClientError as e:
 				print(f"Error retrieving file from Minio: {e}")
 				return None

--- a/django_project/monitor/observation_views.py
+++ b/django_project/monitor/observation_views.py
@@ -243,10 +243,14 @@ def upload_pest_image(request):
 							pest_image.image = image
 							pest_image.save()
 
-							# disabling AI section for now
+
 							# open uploaded image as Pillow object so it can be classified.
-							result = classify_image(Image.open(image))
-							classification_results.append(result)
+							# Check if the uploaded file is an image
+							if pest_image.image.content_type.startswith('image'):
+								result = classify_image(Image.open(pest_image.image))
+								classification_results.append(result)
+							else:
+								classification_results.append({'status': 'error', 'message': 'File is not a valid image.'})
 
 				return JsonResponse(
 					{

--- a/django_project/monitor/observation_views.py
+++ b/django_project/monitor/observation_views.py
@@ -91,15 +91,15 @@ def retrieve_file_from_minio(file_name):
 				return None
 
 # disabling AI section for now
-# file_name = "ai_image_calculation.h5"
-# downloaded_file_path = retrieve_file_from_minio(file_name)
-# if downloaded_file_path:
-# 	try:
-# 		model = keras.models.load_model(downloaded_file_path)
-# 	except OSError:
-# 		model = None
-# else:
-# 	model = None
+file_name = "ai_image_calculation.h5"
+downloaded_file_path = retrieve_file_from_minio(file_name)
+if downloaded_file_path:
+	try:
+		model = keras.models.load_model(downloaded_file_path)
+	except OSError:
+		model = None
+else:
+	model = None
 
 # section for ai score calculations
 # TODO move this into seperate file

--- a/django_project/monitor/observation_views.py
+++ b/django_project/monitor/observation_views.py
@@ -89,15 +89,16 @@ def retrieve_file_from_minio(file_name):
 				print(f"Error retrieving file from Minio: {e}")
 				return None
 
-file_name = "ai_image_calculation.h5"
-downloaded_file_path = retrieve_file_from_minio(file_name)
-if downloaded_file_path:
-	try:
-		model = keras.models.load_model(downloaded_file_path)
-	except OSError:
-		model = None
-else:
-	model = None
+# disabling AI section for now
+# file_name = "ai_image_calculation.h5"
+# downloaded_file_path = retrieve_file_from_minio(file_name)
+# if downloaded_file_path:
+# 	try:
+# 		model = keras.models.load_model(downloaded_file_path)
+# 	except OSError:
+# 		model = None
+# else:
+# 	model = None
 
 # section for ai score calculations
 # TODO move this into seperate file
@@ -241,9 +242,10 @@ def upload_pest_image(request):
 							pest_image.image = image
 							pest_image.save()
 
+							# disabling AI section for now
 							# open uploaded image as Pillow object so it can be classified.
-							result = classify_image(Image.open(image))
-							classification_results.append(result)
+							# result = classify_image(Image.open(image))
+							# classification_results.append(result)
 
 				return JsonResponse(
 					{

--- a/django_project/monitor/observation_views.py
+++ b/django_project/monitor/observation_views.py
@@ -245,8 +245,8 @@ def upload_pest_image(request):
 
 							# disabling AI section for now
 							# open uploaded image as Pillow object so it can be classified.
-							# result = classify_image(Image.open(image))
-							# classification_results.append(result)
+							result = classify_image(Image.open(image))
+							classification_results.append(result)
 
 				return JsonResponse(
 					{

--- a/django_project/monitor/observation_views.py
+++ b/django_project/monitor/observation_views.py
@@ -240,17 +240,16 @@ def upload_pest_image(request):
 								observation=observation,
 								group=group
 							)
-							pest_image.image = image
-							pest_image.save()
+							try:
+								pest_image.image = image
+								pest_image.save()
 
-
-							# open uploaded image as Pillow object so it can be classified.
-							# Check if the uploaded file is an image
-							if pest_image.image.content_type.startswith('image'):
+								# Open the image for classification
 								result = classify_image(Image.open(pest_image.image))
 								classification_results.append(result)
-							else:
-								classification_results.append({'status': 'error', 'message': 'File is not a valid image.'})
+							except (OSError, Image.DecompressionBombError, Image.UnidentifiedImageError) as e:
+								# Handle image recognition errors
+								classification_results.append({'status': 'error', 'message': f'Error recognizing image: {str(e)}'})
 
 				return JsonResponse(
 					{


### PR DESCRIPTION
This PR addresses issues when getting AI model.
- It will first try to get using Minio module. If it fails, it will check if the model is already mounted in /home/web/minio/minisass. If it still fails, it will use boto3 module to treat Minio as S3 to get the model.
- Previously, we classify the image using `classify_image(request.FILES)`. The image that needs to be classified should be a Pillow image object, so I update it to `classify_image(Image.open(image))`. 
- The previous image classification is also done outside the loop, while want to classifiy each image. So I move it inside the loop.

@tinashechiraya That is what I've done after checking on the AI integration.