### PR TITLE
patch:pass img directly

### DIFF
--- a/django_project/monitor/observation_views.py
+++ b/django_project/monitor/observation_views.py
@@ -264,7 +264,7 @@ def upload_pest_image(request):
 								pest_image.save()
 
 								# Open the image for classification
-								result = classify_image(Image.open(image))
+								result = classify_image(image)
 								classification_results.append(result)
 							except (OSError, Image.DecompressionBombError, Image.UnidentifiedImageError) as e:
 								# Handle image recognition errors


### PR DESCRIPTION
this should resolve error   {
            "error": "path should be path-like or io.BytesIO, not <class 'PIL.PngImagePlugin.PngImageFile'>"
        }