### PR TITLE
patch: return all observations view for fbis

### DIFF
--- a/django_project/monitor/observation_views.py
+++ b/django_project/monitor/observation_views.py
@@ -740,6 +740,9 @@ class ObservationListCreateView(generics.ListCreateAPIView):
 	serializer_class = ObservationsSerializer
 	permission_classes = [IsAuthenticated]
 
+class ObservationListView(generics.ListAPIView):
+    queryset = Observations.objects.all()
+    serializer_class = ObservationsSerializer
 
 class ObservationRetrieveUpdateDeleteView(
 		generics.RetrieveUpdateDestroyAPIView

--- a/django_project/monitor/urls.py
+++ b/django_project/monitor/urls.py
@@ -6,6 +6,7 @@ from monitor.observation_views import (
     ObservationRetrieveUpdateDeleteView,
     ObservationRetrieveView,
     RecentObservationListView,
+    ObservationListView,
     create_observations,
     ObservationImageViewSet,
     get_observations_by_site,
@@ -130,6 +131,12 @@ urlpatterns = [
     path(
         'observations/observation-details/<int:observation_pk>/',
         include(router.urls)
+    ),
+
+    path(
+        'observations-list/', 
+        ObservationListView.as_view(), 
+        name='observation-list'
     ),
 
     path(


### PR DESCRIPTION
this will be used on fbis to fetch all observations without requiring authentication

endpoint to consume:
Production
https://minisass.org/monitor/observations/
Staging
https://minisass.sta.do.kartoza.com/monitor/observations/

https://github.com/kartoza/miniSASS/pull/911