### PR TITLE
patch: prevent rivername from being cleared on form

### DIFF
--- a/django_project/minisass_frontend/src/components/ScoreForm/index.tsx
+++ b/django_project/minisass_frontend/src/components/ScoreForm/index.tsx
@@ -174,7 +174,6 @@ const ScoreForm: React.FC<ScoreFormProps> = ({ onCancel, additionalData, setSide
       if(response.status == 200){
         setIsSavingData(false)
         setIsCloseDialogOpen(false)
-        additionalData.riverName = ''
         localStorage.setItem('observationId', JSON.stringify(0))
         localStorage.setItem('siteId', JSON.stringify(0))
         if (response.data.status.includes('error')) {
@@ -189,7 +188,7 @@ const ScoreForm: React.FC<ScoreFormProps> = ({ onCancel, additionalData, setSide
         }else {
           setProceedToSavingData(false);
           setIsSuccessModalOpen(true);
-          setIsDisableNavigations(false)
+          setIsDisableNavigations(false);
         }
       }
     } catch (exception) {


### PR DESCRIPTION
The client requested that when a user should cancel the action on the save observation form ,it not clear the values already entered in the different form fields and currently the only field that was being cleared is rivername