### PR TITLE
patch: generate a non expring token

### DIFF
--- a/django_project/minisass_authentication/tests/test_views.py
+++ b/django_project/minisass_authentication/tests/test_views.py
@@ -11,6 +11,44 @@ from django.utils.http import (
 from django.contrib.auth.tokens import default_token_generator
 from minisass_authentication.tests.factories import UserFactory
 from minisass_authentication.models import PENDING_STATUS
+from rest_framework import status
+
+
+class GenerateSpecialTokenTest(APITestCase):
+    def setUp(self):
+        # Create a test user
+        self.user = User.objects.create_user(
+            username='testuser',
+            email='testuser@example.com',
+            password='testpassword'
+        )
+
+    def test_generate_token_success(self):
+        # Use the user's email to generate a token
+        url = reverse('generate_special_token', args=[self.user.email])
+        response = self.client.post(url)
+
+        # Check that the response is successful
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('token', response.json())
+
+    def test_generate_token_user_not_found(self):
+        # Use a non-existent email
+        url = reverse('generate_special_token', args=['nonexistent@example.com'])
+        response = self.client.post(url)
+
+        # Check that the response indicates the user was not found
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.json(), {'error': 'User not found'})
+
+    def test_generate_token_invalid_email_format(self):
+        # Attempt to use an invalid email format
+        url = reverse('generate_special_token', args=['invalid-email-format'])
+        response = self.client.post(url)
+
+        # Check that the response indicates the user was not found (since email format is not checked)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.json(), {'error': 'User not found'})
 
 
 class PasswordResetTest(APITestCase):

--- a/django_project/minisass_authentication/urls.py
+++ b/django_project/minisass_authentication/urls.py
@@ -26,7 +26,7 @@ from minisass_authentication.views import (
 
 
 urlpatterns = [
-    path('api/generate_special_token/<str:username>', generate_special_token, name='generate_special_token'),
+    path('api/generate-special-token/<str:username>', generate_special_token, name='generate_special_token'),
     path('api/request-reset/', request_password_reset, name='request_password_reset'),
     path('api/verify-password-reset/<uidb64>/<token>/', verify_password_reset, name='verify_password_reset'),
     path('api/update-password-reset/<uid>/<token>/', update_password, name='update_password_reset'),

--- a/django_project/minisass_authentication/urls.py
+++ b/django_project/minisass_authentication/urls.py
@@ -26,7 +26,7 @@ from minisass_authentication.views import (
 
 
 urlpatterns = [
-    path('api/generate_special_token/', generate_special_token, name='generate_special_token'),
+    path('api/generate_special_token/<str:username>', generate_special_token, name='generate_special_token'),
     path('api/request-reset/', request_password_reset, name='request_password_reset'),
     path('api/verify-password-reset/<uidb64>/<token>/', verify_password_reset, name='verify_password_reset'),
     path('api/update-password-reset/<uid>/<token>/', update_password, name='update_password_reset'),

--- a/django_project/minisass_authentication/urls.py
+++ b/django_project/minisass_authentication/urls.py
@@ -20,11 +20,13 @@ from minisass_authentication.views import (
     UploadCertificate,
     UpdatePassword,
     check_is_expert,
-    retrieve_email_by_username
+    retrieve_email_by_username,
+    generate_special_token
 )
 
 
 urlpatterns = [
+    path('api/generate_special_token/', generate_special_token, name='generate_special_token'),
     path('api/request-reset/', request_password_reset, name='request_password_reset'),
     path('api/verify-password-reset/<uidb64>/<token>/', verify_password_reset, name='verify_password_reset'),
     path('api/update-password-reset/<uid>/<token>/', update_password, name='update_password_reset'),

--- a/django_project/minisass_authentication/urls.py
+++ b/django_project/minisass_authentication/urls.py
@@ -26,7 +26,7 @@ from minisass_authentication.views import (
 
 
 urlpatterns = [
-    path('api/generate-special-token/<str:username>', generate_special_token, name='generate_special_token'),
+    path('api/generate-special-token/<str:email>', generate_special_token, name='generate_special_token'),
     path('api/request-reset/', request_password_reset, name='request_password_reset'),
     path('api/verify-password-reset/<uidb64>/<token>/', verify_password_reset, name='verify_password_reset'),
     path('api/update-password-reset/<uid>/<token>/', update_password, name='update_password_reset'),

--- a/django_project/minisass_authentication/views.py
+++ b/django_project/minisass_authentication/views.py
@@ -49,14 +49,17 @@ import logging
 # Get an instance of a logger
 logger = logging.getLogger(__name__)
 
-@api_view(['POST'])
 def generate_special_token(request, email):
     try:
         user = User.objects.get(email=email)
     except User.DoesNotExist:
         return Response({'error': 'User not found'}, status=404)
 
+    if not user.is_staff and not user.is_superuser:
+        return Response({'error': 'User is not an admin'}, status=403)
+
     token = AccessToken.for_user(user)
+    # Set a very long expiration time, e.g., 100 years
     token.set_exp(lifetime=timedelta(days=365 * 100))
 
     return JsonResponse({'token': str(token)}, status=200)

--- a/django_project/minisass_authentication/views.py
+++ b/django_project/minisass_authentication/views.py
@@ -38,6 +38,10 @@ from minisass_authentication.serializers import (
 	UserProfileSerializer
 )
 from minisass_authentication.utils import get_is_user_password_enforced
+from rest_framework_simplejwt.tokens import AccessToken
+from rest_framework.response import Response
+from rest_framework.decorators import api_view
+from datetime import timedelta
 
 User = get_user_model()
 import logging
@@ -45,6 +49,18 @@ import logging
 # Get an instance of a logger
 logger = logging.getLogger(__name__)
 
+@api_view(['POST'])
+def generate_special_token(request, username):
+    try:
+        user = User.objects.get(username=username)
+    except User.DoesNotExist:
+        return Response({'error': 'User not found'}, status=404)
+
+    token = AccessToken.for_user(user)
+    # Set a very long expiration time, e.g., 100 years
+    token.set_exp(lifetime=timedelta(days=365 * 100))
+
+    return Response({'token': str(token)})
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])

--- a/django_project/minisass_authentication/views.py
+++ b/django_project/minisass_authentication/views.py
@@ -50,17 +50,16 @@ import logging
 logger = logging.getLogger(__name__)
 
 @api_view(['POST'])
-def generate_special_token(request, username):
+def generate_special_token(request, email):
     try:
-        user = User.objects.get(username=username)
+        user = User.objects.get(email=email)
     except User.DoesNotExist:
         return Response({'error': 'User not found'}, status=404)
 
     token = AccessToken.for_user(user)
-    # Set a very long expiration time, e.g., 100 years
     token.set_exp(lifetime=timedelta(days=365 * 100))
 
-    return Response({'token': str(token)})
+    return JsonResponse({'token': str(token)}, status=200)
 
 @api_view(['POST'])
 @permission_classes([IsAuthenticated])


### PR DESCRIPTION
generate a non expiring token.
this token is only generated for super users 
example usage of api: 'curl -X POST http://127.0.0.1:8000/testapp/api/generate-special-token/tinashe@kartoza.com'

![lifetime_token](https://github.com/user-attachments/assets/e72601a6-d5d6-43a4-bbb4-9c7b72bc0345)

