### PR TITLE
patch: create seperate serializers for sites and observations

### DIFF
--- a/django_project/monitor/serializers.py
+++ b/django_project/monitor/serializers.py
@@ -3,193 +3,193 @@ from rest_framework import serializers
 from minisass_authentication.models import UserProfile
 from minisass_authentication.serializers import LookupSerializer
 from monitor.models import (
-    Observations,
-    ObservationPestImage,
-    Sites,
-    SiteImage,
-    Assessment,
-    Pest
+	Observations,
+	ObservationPestImage,
+	Sites,
+	SiteImage,
+	Assessment,
+	Pest
 )
 
 
 class ObservationsAllFieldsSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Observations
-        fields = '__all__'
+	class Meta:
+		model = Observations
+		fields = '__all__'
 
 
 class AssessmentSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Assessment
-        fields = '__all__'
+	class Meta:
+		model = Assessment
+		fields = '__all__'
 
 
 class SiteImageSerializer(serializers.ModelSerializer):
-    """Serializer of site images."""
+	"""Serializer of site images."""
 
-    class Meta:
-        model = SiteImage
-        exclude = ('site',)
+	class Meta:
+		model = SiteImage
+		exclude = ('site',)
 
 
 class SitesSerializer(serializers.ModelSerializer):
-    """Serializer of site."""
+	"""Serializer of site."""
 
-    images = serializers.SerializerMethodField()
+	images = serializers.SerializerMethodField()
 
-    def get_images(self, obj):
-        """Return images of site."""
-        return SiteImageSerializer(
-            obj.siteimage_set.all(), many=True
-        ).data
+	def get_images(self, obj):
+		"""Return images of site."""
+		return SiteImageSerializer(
+			obj.siteimage_set.all(), many=True
+		).data
 
-    def to_representation(self, instance):
-        representation = super().to_representation(instance)
+	def to_representation(self, instance):
+		representation = super().to_representation(instance)
 
-        # Fetch the latest observation for the current site
-        latest_observation = instance.observation.order_by('-obs_date').first()
+		# Fetch the latest observation for the current site
+		latest_observation = instance.observation.order_by('-obs_date').first()
 
-        if latest_observation:
-            representation['score'] = latest_observation.score
+		if latest_observation:
+			representation['score'] = latest_observation.score
 
-        return representation
+		return representation
 
-    class Meta:
-        model = Sites
-        fields = '__all__'
+	class Meta:
+		model = Sites
+		fields = '__all__'
 
 
 class ObservationPestImageSerializer(serializers.ModelSerializer):
-    """Serializer for Observation Pert image."""
+	"""Serializer for Observation Pert image."""
 
-    pest_id = serializers.SerializerMethodField()
-    pest_name = serializers.SerializerMethodField()
+	pest_id = serializers.SerializerMethodField()
+	pest_name = serializers.SerializerMethodField()
 
-    ml_score = serializers.FloatField()
-    ml_prediction = serializers.CharField()
+	ml_score = serializers.FloatField()
+	ml_prediction = serializers.CharField()
 
-    def get_pest_id(self, instance):
-        if instance.group:
-            return instance.group_id
-        elif instance.pest:
-            return instance.pest_id
-        return None
+	def get_pest_id(self, instance):
+		if instance.group:
+			return instance.group_id
+		elif instance.pest:
+			return instance.pest_id
+		return None
 
-    def get_pest_name(self, instance):
-        if instance.group:
-            return instance.group.name
-        elif instance.pest:
-            return instance.pest.name
-        return None
+	def get_pest_name(self, instance):
+		if instance.group:
+			return instance.group.name
+		elif instance.pest:
+			return instance.pest.name
+		return None
 
-    class Meta:
-        model = ObservationPestImage
-        exclude = ('observation', 'pest')
+	class Meta:
+		model = ObservationPestImage
+		exclude = ('observation', 'pest')
 
 
 class ObservationsSerializer(serializers.ModelSerializer):
-    """Serializer of observation."""
+	"""Serializer of observation."""
 
-    site = SitesSerializer()
-    sitename = serializers.CharField(source='site.site_name')
-    rivername = serializers.CharField(source='site.river_name')
-    sitedescription = serializers.CharField(source='site.description')
-    rivercategory = serializers.CharField(source='site.river_cat')
-    longitude = serializers.FloatField(source='site.the_geom.x')
-    latitude = serializers.FloatField(source='site.the_geom.y')
-    collectorsname = serializers.SerializerMethodField()
-    organisationtype = serializers.SerializerMethodField()
-    images = serializers.SerializerMethodField()
+	site = SitesSerializer()
+	sitename = serializers.CharField(source='site.site_name')
+	rivername = serializers.CharField(source='site.river_name')
+	sitedescription = serializers.CharField(source='site.description')
+	rivercategory = serializers.CharField(source='site.river_cat')
+	longitude = serializers.FloatField(source='site.the_geom.x')
+	latitude = serializers.FloatField(source='site.the_geom.y')
+	collectorsname = serializers.SerializerMethodField()
+	organisationtype = serializers.SerializerMethodField()
+	images = serializers.SerializerMethodField()
 
-    class Meta:
-        model = Observations
-        fields = '__all__'
+	class Meta:
+		model = Observations
+		fields = '__all__'
 
-    def get_collectorsname(self, obj):
-        """Return collector name."""
-        if obj.collector_name:
-            return obj.collector_name
-        else:
-            user = obj.user
-            return (
-                f"{user.first_name}"
-                if user and user.first_name
-                else "Anonymous"
-            )
+	def get_collectorsname(self, obj):
+		"""Return collector name."""
+		if obj.collector_name:
+			return obj.collector_name
+		else:
+			user = obj.user
+			return (
+				f"{user.first_name}"
+				if user and user.first_name
+				else "Anonymous"
+			)
 
-    def get_organisationtype(self, obj):
-        """Return organisation type."""
-        try:
-            user_profile = UserProfile.objects.get(user=obj.user)
-        except UserProfile.DoesNotExist:
-            user_profile = None
+	def get_organisationtype(self, obj):
+		"""Return organisation type."""
+		try:
+			user_profile = UserProfile.objects.get(user=obj.user)
+		except UserProfile.DoesNotExist:
+			user_profile = None
 
-        if user_profile:
-            organisation_type = user_profile.organisation_type
-            serialized_organisation_type = LookupSerializer(
-                organisation_type).data
-            return serialized_organisation_type
-        else:
-            return None
+		if user_profile:
+			organisation_type = user_profile.organisation_type
+			serialized_organisation_type = LookupSerializer(
+				organisation_type).data
+			return serialized_organisation_type
+		else:
+			return None
 
-    def get_images(self, obj: Observations):
-        """Return images of site."""
-        return ObservationPestImageSerializer(
-            obj.observationpestimage_set.all().order_by('pest__name', '-id'), many=True
-        ).data
+	def get_images(self, obj: Observations):
+		"""Return images of site."""
+		return ObservationPestImageSerializer(
+			obj.observationpestimage_set.all().order_by('pest__name', '-id'), many=True
+		).data
 
-    # Include the comment field explicitly
-    comment = serializers.CharField(allow_blank=True, default='')
+	# Include the comment field explicitly
+	comment = serializers.CharField(allow_blank=True, default='')
 
-    def create(self, validated_data):
-        if 'comment' not in validated_data:
-            validated_data['comment'] = ''
-        return super().create(validated_data)
-     
+	def create(self, validated_data):
+		if 'comment' not in validated_data:
+			validated_data['comment'] = ''
+		return super().create(validated_data)
+	 
 
 
 class SitesWithObservationsSerializer(serializers.ModelSerializer):
-    sitename = serializers.CharField(source='site_name')
-    rivername = serializers.CharField(source='river_name')
-    sitedescription = serializers.CharField(source='description')
-    rivercategory = serializers.CharField(source='river_cat')
-    longitude = serializers.FloatField(source='the_geom.x')
-    latitude = serializers.FloatField(source='the_geom.y')
-    images = serializers.SerializerMethodField()
+	sitename = serializers.CharField(source='site_name')
+	rivername = serializers.CharField(source='river_name')
+	sitedescription = serializers.CharField(source='description')
+	rivercategory = serializers.CharField(source='river_cat')
+	longitude = serializers.FloatField(source='the_geom.x')
+	latitude = serializers.FloatField(source='the_geom.y')
+	images = serializers.SerializerMethodField()
 
-    class Meta:
-        model = Sites
-        fields = '__all__'
+	class Meta:
+		model = Sites
+		fields = '__all__'
 
 
-    def get_images(self, obj: Sites):
-        """Return images of site."""
-        return SiteImageSerializer(
-            obj.siteimage_set.all(), many=True
-        ).data
+	def get_images(self, obj: Sites):
+		"""Return images of site."""
+		return SiteImageSerializer(
+			obj.siteimage_set.all(), many=True
+		).data
 
-    def to_representation(self, instance):
-        data = super().to_representation(instance)
+	def to_representation(self, instance):
+		data = super().to_representation(instance)
 
-        # Query for observations related to the site
-        observations = Observations.objects.filter(site_id=instance.gid).order_by('-obs_date', '-gid')
-        serializer = ObservationsSerializer(observations, many=True)
+		# Query for observations related to the site
+		observations = Observations.objects.filter(site_id=instance.gid).order_by('-obs_date', '-gid')
+		serializer = ObservationsSerializer(observations, many=True)
 
-        combined_data = {
-            'site': {
-                'gid': instance.gid,
-                'sitename': data['sitename'],
-                'rivername': data['rivername'],
-                'rivercategory': data['rivercategory'],
-                'sitedescription': data['sitedescription'],
-                'longitude': instance.the_geom.x,
-                'latitude': instance.the_geom.y,
-                'images': data['images'],
-            },
-            'observations': serializer.data,
-        }
+		combined_data = {
+			'site': {
+				'gid': instance.gid,
+				'sitename': data['sitename'],
+				'rivername': data['rivername'],
+				'rivercategory': data['rivercategory'],
+				'sitedescription': data['sitedescription'],
+				'longitude': instance.the_geom.x,
+				'latitude': instance.the_geom.y,
+				'images': data['images'],
+			},
+			'observations': serializer.data,
+		}
 
-        return combined_data
+		return combined_data
 
 class ObservationsDataOnlySerializer(serializers.ModelSerializer):
 	"""Serializer of observation."""

--- a/django_project/monitor/serializers.py
+++ b/django_project/monitor/serializers.py
@@ -236,8 +236,9 @@ class SitesAndObservationsSerializer(serializers.ModelSerializer):
 	images = serializers.SerializerMethodField()
 
 	def get_images(self, obj: Sites):
-		return ObservationPestImageSerializer(
-			obj.observationpestimage_set.all().order_by('pest__name', '-id'), many=True
+		"""Return images of site."""
+		return SiteImageSerializer(
+			obj.siteimage_set.all(), many=True
 		).data
 
 	class Meta:

--- a/django_project/monitor/site_views.py
+++ b/django_project/monitor/site_views.py
@@ -15,7 +15,8 @@ from monitor.serializers import (
 	SitesSerializer,
 	SitesWithObservationsSerializer,
 	SiteImageSerializer,
-	ObservationPestImageSerializer
+	ObservationPestImageSerializer,
+	SitesAndObservationsSerializer
 )
 
 class SaveObservationImagesView(generics.CreateAPIView):
@@ -195,6 +196,7 @@ class SiteObservationsByLocation(APIView):
 		
 
 class SitesWithObservationsView(APIView):
+	serializer_class = SitesAndObservationsSerializer
 	def get(self, request):
 		start_date_str = request.query_params.get('start_date', None)
 		start_date = parse_date(start_date_str) if start_date_str else None
@@ -209,5 +211,5 @@ class SitesWithObservationsView(APIView):
 		else:
 			sites = Sites.objects.all()
 
-		serializer = SitesWithObservationsSerializer(sites, many=True)
+		serializer = self.serializer_class(sites, many=True)
 		return Response(serializer.data, status=status.HTTP_200_OK)

--- a/django_project/monitor/tests/test_sites.py
+++ b/django_project/monitor/tests/test_sites.py
@@ -89,9 +89,13 @@ class SitesListCreateViewTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 3)
         
-        # Check structure and content of the response
+        # Check that the 'site' key is present
         self.assertIn('site', response.data[0])
-        self.assertIn('observations', response.data[1])
+        
+        # Check that the 'observations' key is present within the 'site'
+        self.assertIn('observations', response.data[0]['site'])
+
+        # Check the validity of the returned data
         self.assertEqual(response.data[0]['site']['gid'], self.site.gid)
         self.assertEqual(response.data[1]['site']['gid'], self.site1.gid)
 
@@ -104,7 +108,7 @@ class SitesListCreateViewTestCase(TestCase):
         
         # Check structure and content of the response
         self.assertIn('site', response.data[0])
-        self.assertIn('observations', response.data[0])
+        self.assertIn('observations', response.data[0]['site'])
         self.assertEqual(response.data[0]['site']['gid'], self.site1.gid)
 
     def test_get_sites_with_observations_with_no_data(self):


### PR DESCRIPTION
The existing serializers return combined data for sites and observations as this is the expected result on the frontend however for this API the data requires a better structure which is why i have created these additional serialzers so that the output structure matches the one requested by the client

![sites_with_observations_api](https://github.com/user-attachments/assets/2f5e47e3-0874-436b-9060-f637323e080f)


example usage: '/sites-with-observations/?start_date=2023-03-13'