### PR TITLE
patch: construct full url path for site and observation images

### DIFF
--- a/django_project/monitor/serializers.py
+++ b/django_project/monitor/serializers.py
@@ -218,13 +218,13 @@ class ObservationsDataOnlySerializer(serializers.ModelSerializer):
 		"""Return images of observation with full URL paths."""
 		domain = Site.objects.get_current().domain
 		images = obj.observationpestimage_set.all().order_by('pest__name', '-id')
-		return [
-			{
-				'id': image.id,
-				'image': f'https://{domain}{image.image.url}'
-			}
-			for image in images
-		]
+		serialized_images = ObservationPestImageSerializer(images, many=True).data
+		
+		for image in serialized_images:
+			if 'image' in image:
+				image['image'] = f'https://{domain}{image["image"]}'
+		
+		return serialized_images
 
 	comment = serializers.CharField(allow_blank=True, default='')
 
@@ -246,13 +246,13 @@ class SitesAndObservationsSerializer(serializers.ModelSerializer):
 		"""Return images of site with full URL paths."""
 		domain = Site.objects.get_current().domain
 		images = obj.siteimage_set.all()
-		return [
-			{
-				'id': image.id,
-				'image': f'https://{domain}{image.image.url}'
-			}
-			for image in images
-		]
+		serialized_images = SiteImageSerializer(images, many=True).data
+		
+		for image in serialized_images:
+			if 'image' in image:
+				image['image'] = f'https://{domain}{image["image"]}'
+		
+		return serialized_images
 
 	class Meta:
 		model = Sites

--- a/django_project/monitor/serializers.py
+++ b/django_project/monitor/serializers.py
@@ -10,6 +10,7 @@ from monitor.models import (
 	Assessment,
 	Pest
 )
+from django.contrib.sites.models import Site
 
 
 class ObservationsAllFieldsSerializer(serializers.ModelSerializer):
@@ -214,10 +215,16 @@ class ObservationsDataOnlySerializer(serializers.ModelSerializer):
 			)
 
 	def get_images(self, obj: Observations):
-		"""Return images of site."""
-		return ObservationPestImageSerializer(
-			obj.observationpestimage_set.all().order_by('pest__name', '-id'), many=True
-		).data
+		"""Return images of observation with full URL paths."""
+		domain = Site.objects.get_current().domain
+		images = obj.observationpestimage_set.all().order_by('pest__name', '-id')
+		return [
+			{
+				'id': image.id,
+				'image': f'https://{domain}{image.image.url}'
+			}
+			for image in images
+		]
 
 	comment = serializers.CharField(allow_blank=True, default='')
 
@@ -236,10 +243,16 @@ class SitesAndObservationsSerializer(serializers.ModelSerializer):
 	images = serializers.SerializerMethodField()
 
 	def get_images(self, obj: Sites):
-		"""Return images of site."""
-		return SiteImageSerializer(
-			obj.siteimage_set.all(), many=True
-		).data
+		"""Return images of site with full URL paths."""
+		domain = Site.objects.get_current().domain
+		images = obj.siteimage_set.all()
+		return [
+			{
+				'id': image.id,
+				'image': f'https://{domain}{image.image.url}'
+			}
+			for image in images
+		]
 
 	class Meta:
 		model = Sites


### PR DESCRIPTION
before the image path returned:

"images": 
[
                {
                    "id": 26,
                    "image": "/minio-media/minisass/sites/1/2023-07-31_16-55.png"
                },
                {
                    "id": 27,
                    "image": "/minio-media/minisass/sites/1/2023-07-31_16-58.png"
                },
]

and this is only useful on the frontend.

So the modified output
"images": 
[
      {
          "id": 26,
          "image": "https://minisass.sta.do.kartoza.com/minio-media/minisass/sites/1/2023-07-31_16-55.png"
      },
      {
          "id": 27,
          "image": "https://minisass.sta.do.kartoza.com/minio-media/minisass/sites/1/2023-07-31_16-58.png"
      },
}

This is for when the client uses the API ,they will be able to download or view the images in the browser

![example_output](https://github.com/user-attachments/assets/24aab182-5eed-4925-9b63-d1c2212bca87)
