### PR TITLE
patch: add request object to the context

### DIFF
--- a/django_project/monitor/site_views.py
+++ b/django_project/monitor/site_views.py
@@ -211,5 +211,5 @@ class SitesWithObservationsView(APIView):
 		else:
 			sites = Sites.objects.all()
 
-		serializer = self.serializer_class(sites, many=True)
+		serializer = self.serializer_class(sites, many=True, context={'request': request})
 		return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
The previous solution was returning this constructed path:
 "images": [
                {
                    "id": 26,
                    "image": "https://minisass/minio-media/minisass/sites/1/2023-07-31_16-55.png"
                },
}
which is missing https://minisass.sta.do.kartoza.com/

![output](https://github.com/user-attachments/assets/a262ce38-a4ee-43c9-a23c-a96c1f10daf5)


so this new modification resolves that 
so the new output path:
 "images": [
                {
                    "id": 26,
                    "image": " https://minisass.sta.do.kartoza.com/minio-media/minisass/sites/1/2023-07-31_16-55.png"
                },
}