### PR TITLE
patch: fetch and render announcements

### DIFF
--- a/deployment/docker/requirements.txt
+++ b/deployment/docker/requirements.txt
@@ -34,6 +34,8 @@ lxml==4.9.3
 oauthlib==3.2.2
 packaging==23.2
 Pillow==10.1.0
+pinax-announcements==4.0.1
+pinax-templates==3.0.0
 platformdirs==3.11.0
 psycopg2==2.9.9
 pycparser==2.21

--- a/django_project/minisass/settings.py
+++ b/django_project/minisass/settings.py
@@ -206,6 +206,9 @@ INSTALLED_APPS = [
     'minisass_authentication',
     'monitor',
     'minisass',
+    'pinax.announcements',
+    'bootstrapform',
+    'pinax.templates',
     # 'google_analytics'
 ]
 

--- a/django_project/minisass/urls.py
+++ b/django_project/minisass/urls.py
@@ -7,7 +7,8 @@ from django.views.i18n import JavaScriptCatalog
 from minisass.views import (
     GroupScoresListView,
     VideoListView,
-    GetMobileApp
+    GetMobileApp,
+    get_announcements
 )
 
 from minisass_frontend.views import ReactHomeView
@@ -18,6 +19,7 @@ urlpatterns = [
     path('group-scores/', GroupScoresListView.as_view(), name='group-scores'),
     path('videos/', VideoListView.as_view(), name='video-list'),
     path('mobile-app/', GetMobileApp.as_view(), name='get-mobile-app'),
+    path('announcements/', get_announcements, name='get_announcements'),
 
     path('jsi18n/<str:packages>/', JavaScriptCatalog.as_view(), name='javascript-catalog'),  # Use JavaScriptCatalog directly
     path('admin/', admin.site.urls),

--- a/django_project/minisass/views.py
+++ b/django_project/minisass/views.py
@@ -13,6 +13,7 @@ from minisass.serializers import (
 )
 from django.http import JsonResponse
 from pinax.announcements.models import Announcement
+from django.utils.timezone import now
 
 class GroupScoresListView(generics.ListAPIView):
     queryset = GroupScores.objects.all().order_by('name')
@@ -33,6 +34,12 @@ class GetMobileApp(APIView):
 
 
 def get_announcements(request):
-    announcements = Announcement.objects.all().values('title', 'content', 'dismissal_type')
+    current_time = now()
+
+    announcements = Announcement.objects.filter(
+        publish_start__lte=current_time,
+        publish_end__gte=current_time
+    ).values('title', 'content', 'dismissal_type')
+
     return JsonResponse(list(announcements), safe=False)
 

--- a/django_project/minisass/views.py
+++ b/django_project/minisass/views.py
@@ -11,6 +11,8 @@ from minisass.serializers import (
     VideoSerializer,
     MobileAppSerializer
 )
+from django.http import JsonResponse
+from pinax.announcements.models import Announcement
 
 class GroupScoresListView(generics.ListAPIView):
     queryset = GroupScores.objects.all().order_by('name')
@@ -28,3 +30,9 @@ class GetMobileApp(APIView):
     def get(self, request):
         mobile_app = MobileApp.objects.filter(active=True).order_by('-id').first()
         return Response(self.serializer_class(mobile_app).data)
+
+
+def get_announcements(request):
+    announcements = Announcement.objects.all().values('title', 'content', 'dismissal_type')
+    return JsonResponse(list(announcements), safe=False)
+

--- a/django_project/minisass_frontend/src/components/Banner/index.tsx
+++ b/django_project/minisass_frontend/src/components/Banner/index.tsx
@@ -1,12 +1,14 @@
 import React, { useState, useEffect } from 'react';
 import { AiOutlineClose } from 'react-icons/ai';
+import { globalVariables } from '../../utils';
 
 const Banner: React.FC = () => {
   const [visible, setVisible] = useState(true);
   const [announcements, setAnnouncements] = useState([]);
 
+  const announcements_url = globalVariables.baseUrl + '/api/announcements/'
   useEffect(() => {
-    fetch('/api/announcements/')
+    fetch(announcements_url)
       .then((response) => response.json())
       .then((data) => setAnnouncements(data))
       .catch((error) => console.error('Error fetching announcements:', error));

--- a/django_project/minisass_frontend/src/components/Banner/index.tsx
+++ b/django_project/minisass_frontend/src/components/Banner/index.tsx
@@ -3,9 +3,9 @@ import { AiOutlineClose } from 'react-icons/ai';
 import { globalVariables } from '../../utils';
 
 const Banner: React.FC = () => {
-  const [visible, setVisible] = useState(true);
+  const [visible, setVisible] = useState(false);
   const [announcements, setAnnouncements] = useState([]);
-  const [dismissalType, setDismissalType] = useState<number | null>(null);
+  const [showCloseButton, setShowCloseButton] = useState(false);
 
   const announcements_url = globalVariables.baseUrl + '/announcements/';
   
@@ -14,24 +14,27 @@ const Banner: React.FC = () => {
     fetch(announcements_url)
       .then((response) => response.json())
       .then((data) => {
-        setAnnouncements(data);
         if (data.length > 0) {
-          setDismissalType(data[0].dismissal_type);
+          setAnnouncements(data);
+          const shouldShowCloseButton = data.some(announcement => announcement.dismissal_type !== 1);
+          setShowCloseButton(shouldShowCloseButton);
+          setVisible(true); 
+        } else {
+          setVisible(false);
         }
       })
       .catch((error) => console.error('Error fetching announcements:', error));
   }, []);
 
-  // Handle visibility based on dismissal type
   useEffect(() => {
-    if (dismissalType !== 1 && visible) {
+    if (showCloseButton && visible) {
       const timer = setTimeout(() => {
         setVisible(false);
       }, 15000);
 
       return () => clearTimeout(timer);
     }
-  }, [visible, dismissalType]);
+  }, [visible, showCloseButton]);
 
   const bannerStyle: React.CSSProperties = {
     backgroundColor: '#003f81',
@@ -65,7 +68,7 @@ const Banner: React.FC = () => {
 
   return (
     <>
-      {visible && announcements.length > 0 && (
+      {visible && (
         <div style={bannerStyle}>
           <div style={textStyle}>
             {announcements.map((announcement, index) => (
@@ -75,7 +78,7 @@ const Banner: React.FC = () => {
               </div>
             ))}
           </div>
-          {(dismissalType !== 1) && (
+          {showCloseButton && (
             <button onClick={() => setVisible(false)} style={buttonStyle}>
               <AiOutlineClose size={24} />
             </button>

--- a/django_project/minisass_frontend/src/components/Banner/index.tsx
+++ b/django_project/minisass_frontend/src/components/Banner/index.tsx
@@ -5,24 +5,33 @@ import { globalVariables } from '../../utils';
 const Banner: React.FC = () => {
   const [visible, setVisible] = useState(true);
   const [announcements, setAnnouncements] = useState([]);
+  const [dismissalType, setDismissalType] = useState<number | null>(null);
 
-  const announcements_url = globalVariables.baseUrl + '/api/announcements/'
+  const announcements_url = globalVariables.baseUrl + '/announcements/';
+  
+  // Fetch announcements from the API
   useEffect(() => {
     fetch(announcements_url)
       .then((response) => response.json())
-      .then((data) => setAnnouncements(data))
+      .then((data) => {
+        setAnnouncements(data);
+        if (data.length > 0) {
+          setDismissalType(data[0].dismissal_type);
+        }
+      })
       .catch((error) => console.error('Error fetching announcements:', error));
   }, []);
 
+  // Handle visibility based on dismissal type
   useEffect(() => {
-    if (visible) {
+    if (dismissalType !== 1 && visible) {
       const timer = setTimeout(() => {
         setVisible(false);
       }, 15000);
 
       return () => clearTimeout(timer);
     }
-  }, [visible]);
+  }, [visible, dismissalType]);
 
   const bannerStyle: React.CSSProperties = {
     backgroundColor: '#003f81',
@@ -50,7 +59,6 @@ const Banner: React.FC = () => {
     color: 'white',
     background: 'transparent',
     border: 'none',
-    marginTop: '2%',
     display: 'flex',
     alignItems: 'center'
   };
@@ -67,9 +75,11 @@ const Banner: React.FC = () => {
               </div>
             ))}
           </div>
-          <button onClick={() => setVisible(false)} style={buttonStyle}>
-            <AiOutlineClose size={24} />
-          </button>
+          {(dismissalType !== 1) && (
+            <button onClick={() => setVisible(false)} style={buttonStyle}>
+              <AiOutlineClose size={24} />
+            </button>
+          )}
         </div>
       )}
     </>

--- a/django_project/minisass_frontend/src/components/Banner/index.tsx
+++ b/django_project/minisass_frontend/src/components/Banner/index.tsx
@@ -2,16 +2,25 @@ import React, { useState, useEffect } from 'react';
 import { AiOutlineClose } from 'react-icons/ai';
 
 const Banner: React.FC = () => {
-  const [visible, setVisible] = useState(false);
+  const [visible, setVisible] = useState(true);
+  const [announcements, setAnnouncements] = useState([]);
 
   useEffect(() => {
-    if(visible)
+    fetch('/api/announcements/')
+      .then((response) => response.json())
+      .then((data) => setAnnouncements(data))
+      .catch((error) => console.error('Error fetching announcements:', error));
+  }, []);
+
+  useEffect(() => {
+    if (visible) {
       const timer = setTimeout(() => {
         setVisible(false);
       }, 15000);
 
-    return () => clearTimeout(timer);
-  }, []);
+      return () => clearTimeout(timer);
+    }
+  }, [visible]);
 
   const bannerStyle: React.CSSProperties = {
     backgroundColor: '#003f81',
@@ -32,8 +41,7 @@ const Banner: React.FC = () => {
 
   const textStyle: React.CSSProperties = {
     flex: 1,
-    textAlign: 'center',
-    marginTop: '2%'
+    textAlign: 'center'
   };
 
   const buttonStyle: React.CSSProperties = {
@@ -47,15 +55,17 @@ const Banner: React.FC = () => {
 
   return (
     <>
-      {visible && (
+      {visible && announcements.length > 0 && (
         <div style={bannerStyle}>
-          <span style={textStyle}>
-            The miniSASS site will undergo routine maintenance on Friday, 30th August 2024. We apologize for any inconvenience caused by the brief downtime.
-          </span>
-          <button
-            onClick={() => setVisible(false)}
-            style={buttonStyle}
-          >
+          <div style={textStyle}>
+            {announcements.map((announcement, index) => (
+              <div key={index}>
+                <strong>{announcement.title}</strong><br />
+                {announcement.content}
+              </div>
+            ))}
+          </div>
+          <button onClick={() => setVisible(false)} style={buttonStyle}>
             <AiOutlineClose size={24} />
           </button>
         </div>


### PR DESCRIPTION
![adding_announcement_from_backend](https://github.com/user-attachments/assets/9a325414-7111-4784-832e-7923b413d556)
![custom_api_to_fetch_announcements](https://github.com/user-attachments/assets/0f0d6a59-2e64-4c10-8c70-9bf4a8b24fa0)

Description
The admin can add an announcement from the django admin specifying the time
and user will see announcement via the component for banners defined on the frontend