### PR TITLE
patch: update test results

### DIFF
--- a/django_project/minisass_authentication/tests/test_views.py
+++ b/django_project/minisass_authentication/tests/test_views.py
@@ -210,7 +210,7 @@ class UpdateUserTest(APITestCase):
 
     def test_not_authenticated(self):
         response = self.client.get(self.url)
-        self.assertEquals(response.status_code, 401)
+        self.assertEquals(response.status_code, 403)
 
     def test_update_works(self):
         self.client.force_authenticate(self.user)
@@ -339,7 +339,7 @@ class CheckAuthenticationStatusTest(APITestCase):
 
     def test_check_authentication_status_unauthenticated(self):
         response = self.client.get(self.url)
-        self.assertEquals(response.status_code, 401)
+        self.assertEquals(response.status_code, 403)
         self.assertEquals(
             response.json(),
             {'detail': 'Authentication credentials were not provided.'}


### PR DESCRIPTION
![image (3)](https://github.com/user-attachments/assets/19fefe89-2511-425d-a541-2b9cd7fdb95c)


these test are expecting a 403 forbidden as opposed to a 401 unauthorized this is likely due to an update 
IsAuthenticated permission class in UpdateUser view, the view is protected by the authentication layer, and Django is not treating unauthenticated access as a 401 error but instead as a 403 due to permission checks.