### PR TITLE
patch: add missing foward slash

### DIFF
--- a/django_project/minisass_frontend/src/components/UserMenu/index.tsx
+++ b/django_project/minisass_frontend/src/components/UserMenu/index.tsx
@@ -100,7 +100,7 @@ export default function UserMenu(props: {setUpdateProfileOpen: void, isDisableNa
         {
           state.user.is_admin &&
           <Link
-            href={`${globalVariables.baseUrl}/admin`}
+            href={`${globalVariables.baseUrl}/admin/`}
             style={{textDecoration: 'none', color: 'inherit'}}
           >
             <MenuItem


### PR DESCRIPTION
when you click the admin link it fails to open the link because of the missing forward slash

![missing foward slash](https://github.com/user-attachments/assets/bf20820a-32a7-43a2-b215-490f09bad830)
