### PR TITLE
Patch use authentication on api

### DIFF
--- a/django_project/monitor/site_views.py
+++ b/django_project/monitor/site_views.py
@@ -20,6 +20,7 @@ from minisass.models import GroupScores
 from django.utils.dateparse import parse_date
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
+from minisass_authentication.permissions import IsAuthenticatedOrWhitelisted
 
 
 from monitor.serializers import (
@@ -203,6 +204,7 @@ class SiteObservationsByLocation(APIView):
 
 class SitesWithObservationsView(APIView):
 	serializer_class = SitesAndObservationsSerializer
+	permission_classes = [IsAuthenticatedOrWhitelisted]
 	@swagger_auto_schema(
 		operation_description="Retrieve detailed information about a site, including its observations and images.",
 		manual_parameters=[

--- a/django_project/monitor/site_views.py
+++ b/django_project/monitor/site_views.py
@@ -20,7 +20,8 @@ from minisass.models import GroupScores
 from django.utils.dateparse import parse_date
 from drf_yasg.utils import swagger_auto_schema
 from drf_yasg import openapi
-from minisass_authentication.permissions import IsAuthenticatedOrWhitelisted
+from rest_framework_simplejwt.authentication import JWTAuthentication
+from rest_framework.permissions import IsAuthenticated
 
 
 from monitor.serializers import (
@@ -204,7 +205,8 @@ class SiteObservationsByLocation(APIView):
 
 class SitesWithObservationsView(APIView):
 	serializer_class = SitesAndObservationsSerializer
-	permission_classes = [IsAuthenticatedOrWhitelisted]
+	authentication_classes = [JWTAuthentication]
+	permission_classes = [IsAuthenticated]
 	@swagger_auto_schema(
 		operation_description="Retrieve detailed information about a site, including its observations and images.",
 		manual_parameters=[

--- a/django_project/monitor/tests/test_sites.py
+++ b/django_project/monitor/tests/test_sites.py
@@ -30,8 +30,11 @@ class SitesListCreateViewTestCase(TestCase):
     def setUp(self):
         # Create a user for authentication
         self.user = User.objects.create_user(username='testuser', password='testpassword', email='test@example.com')
-        self.client = APIClient()
-        self.client.force_authenticate(user=self.user)
+        self.user_token = User.objects.create_superuser(
+            username='testuser2', 
+            password='testpassword', 
+            email='test@example2.com'
+        )
         self.site = Sites.objects.create(
             site_name='Test Site',
             river_name='Test River',
@@ -83,6 +86,15 @@ class SitesListCreateViewTestCase(TestCase):
             elec_cond="2.50",
             elec_cond_unit="mS/m"
         )
+        self.token = self.generate_token_for_user(self.user_token.email)
+        self.client = APIClient()
+        self.client.credentials(HTTP_AUTHORIZATION='Bearer ' + self.token)
+
+    def generate_token_for_user(self, email):
+        url = reverse('generate_special_token', args=[email])
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json().get('token')
 
 
     def test_get_all_sites_with_observations(self):
@@ -121,13 +133,15 @@ class SitesListCreateViewTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 0)
 
-    def test_get_sites_with_observations_without_authentication(self):
-        self.client.delete
-        self.client = APIClient()
+    def test_get_sites_with_observations_without_token(self):
+        # Remove token authentication for this request
+        self.client.credentials()
         
         url = reverse('sites-with-observations')
         response = self.client.get(url)
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # Expect 401 Unauthorized without a token
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     
     def test_multiple_image_upload(self):

--- a/django_project/monitor/tests/test_sites.py
+++ b/django_project/monitor/tests/test_sites.py
@@ -30,6 +30,8 @@ class SitesListCreateViewTestCase(TestCase):
     def setUp(self):
         # Create a user for authentication
         self.user = User.objects.create_user(username='testuser', password='testpassword', email='test@example.com')
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.user)
         self.site = Sites.objects.create(
             site_name='Test Site',
             river_name='Test River',
@@ -118,6 +120,14 @@ class SitesListCreateViewTestCase(TestCase):
         response = self.client.get(url, {'start_date': start_date})
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 0)
+
+    def test_get_sites_with_observations_without_authentication(self):
+        self.client.delete
+        self.client = APIClient()
+        
+        url = reverse('sites-with-observations')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     
     def test_multiple_image_upload(self):


### PR DESCRIPTION

Description 
The 3rd party API now requires token based authentication to access data.

This token can be obtained in the following:

- create a super user (will be done by devOps for digital twin..We will need their email)
- use super users email to generate a token from 'api/generate-special-token/example@email.com'  endpoint
- retrieve token and use with api:  'monitor/sites-with-observations'

This is linked to pr https://github.com/kartoza/miniSASS/pull/1053

and linked to task https://github.com/kartoza/miniSASS/issues/1097