### PR TITLE
Feature/1105 remove unused table

### DIFF
--- a/django_project/monitor/admin.py
+++ b/django_project/monitor/admin.py
@@ -6,7 +6,6 @@ from minisass_authentication.models import UserProfile
 
 from monitor.forms import ObservationPestImageForm
 from .models import (
-    Assessment,
     Sites,
     Observations,
     SiteImage,
@@ -257,4 +256,3 @@ class SitesAdmin(admin.ModelAdmin):
 
 
 admin.site.register(ObservationPestImage)
-admin.site.register(Assessment, admin.ModelAdmin)

--- a/django_project/monitor/admin.py
+++ b/django_project/monitor/admin.py
@@ -3,6 +3,7 @@ import csv
 from django.utils.encoding import smart_str
 from django.http import HttpResponse
 from minisass_authentication.models import UserProfile
+from django.contrib.sites.models import Site
 
 from monitor.forms import ObservationPestImageForm
 from .models import (
@@ -256,3 +257,4 @@ class SitesAdmin(admin.ModelAdmin):
 
 
 admin.site.register(ObservationPestImage)
+admin.site.unregister(Site)


### PR DESCRIPTION
This is PR for https://github.com/kartoza/miniSASS/issues/1105
I've hidden Assessment and Django Site's table. Assessment table is not removed as it was planned to be used in mobile app. In case it would still be used in the future, we just hide it.
![image](https://github.com/user-attachments/assets/3564f4c8-c937-4726-9a86-62e7f08ff38d)
