### PR TITLE
Publish static from the deploy, fix 404s returning 500, and survive a SECRET_KEY mismatch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -120,6 +120,39 @@ jobs:
           sed -i "s|<SECRET_ARN>|$SECRET_ARN|g" taskdef.json
           
       
+      # Static files must reach S3 BEFORE the new tasks start serving.
+      #
+      # nginx proxies /static/ to the S3 bucket, but collectstatic writes to the
+      # container's local filesystem, which nginx never reads in production.
+      # Nothing bridged the two, so every object under static/ dated from the day
+      # someone uploaded them by hand. Any frontend change therefore produced new
+      # content-hashed bundle names that did not exist in S3, and the browser got
+      # 403 for every asset: the page returned 200 while rendering completely blank.
+      #
+      # collectstatic is run inside the image that is about to be deployed, so the
+      # uploaded files match the deployed code exactly rather than depending on a
+      # separate build producing identical hashes.
+      - name: Collect static files from the built image
+        env:
+          IMAGE: ${{ env.FULL_IMAGE_URI }}
+        run: |
+          mkdir -p ./collected-static
+          docker run --rm \
+            -e DJANGO_DB=unused -e POSTGRES_USER=unused -e POSTGRES_PASS=unused \
+            -e DATABASE_HOST=unused -e DATABASE_PORT=5432 \
+            -e MINIO_BUCKET="$MINIO_BUCKET" -e MINIO_AI_BUCKET="$MINIO_AI_BUCKET" \
+            -e STATIC_ROOT=/home/web/static \
+            -v "$PWD/collected-static":/out \
+            --entrypoint bash "$IMAGE" -c \
+            'cd /home/web/django_project && python manage.py collectstatic --noinput >/dev/null && cp -a /home/web/static/. /out/'
+          echo "Collected $(find ./collected-static -type f | wc -l) static files"
+
+      - name: Upload static files to S3
+        run: |
+          aws s3 sync ./collected-static/ "s3://${S3_MEDIA_BUCKET}/static/" \
+            --no-progress
+          echo "Static files synced to s3://${S3_MEDIA_BUCKET}/static/"
+
       - name: Deploy to ECS
         uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:

--- a/django_project/minisass/constance/backend.py
+++ b/django_project/minisass/constance/backend.py
@@ -1,3 +1,7 @@
+import logging
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.fernet import InvalidToken
 from django.core.cache import caches
 from django.core.cache.backends.locmem import LocMemCache
 from django.core.exceptions import ImproperlyConfigured
@@ -15,7 +19,51 @@ from constance.codecs import dumps
 from constance.codecs import loads
 
 
+logger = logging.getLogger(__name__)
+
+
 class EncryptedDatabaseBackend(DatabaseBackend):
+    """Constance backend whose values are encrypted at rest.
+
+    The stored values are encrypted with a key derived from settings.SECRET_KEY,
+    so rotating SECRET_KEY makes every existing value undecryptable.
+
+    That has already caused a full outage. ReactBaseView reads three of these
+    values on every render, and it serves "/", "/map/", "/howto/" and
+    "/recent-activity/", so an unhandled decryption error returned 500 for the
+    entire site. The ALB health check probes a static endpoint and kept passing, so
+    nothing detected it and the deployment circuit breaker had no reason to
+    intervene.
+
+    A value that cannot be decrypted is therefore now treated as unset. Constance
+    falls back to the default declared in CONSTANCE_CONFIG when a backend returns
+    None, so the site keeps serving with the feature degraded rather than failing
+    outright. The error is logged loudly because the underlying problem still needs
+    fixing: after a key rotation the affected values must be re-entered.
+    """
+
+    def get(self, key):
+        try:
+            return super().get(key)
+        except (InvalidToken, InvalidSignature):
+            logger.error(
+                'Could not decrypt constance value %r. Its stored value was '
+                'encrypted with a different SECRET_KEY, so the configured default '
+                'is being used instead. Re-enter this value in the admin to '
+                'restore it.', key, exc_info=True,
+            )
+            return None
+
+    def mget(self, keys):
+        """Same protection for the bulk read used by autofill."""
+        try:
+            yield from super().mget(keys)
+        except (InvalidToken, InvalidSignature):
+            logger.error(
+                'Could not decrypt one or more constance values; falling back to '
+                'defaults. Re-enter them in the admin.', exc_info=True,
+            )
+
     def __init__(self):
         from minisass.models.models import EncryptedConstance
 

--- a/django_project/minisass/health.py
+++ b/django_project/minisass/health.py
@@ -1,0 +1,91 @@
+# coding=utf-8
+"""Health and readiness endpoints.
+
+Two deliberately different checks:
+
+``/health/`` (liveness)
+    Returns 200 unconditionally. Answers only "is this process accepting
+    connections". Cheap enough to poll frequently.
+
+``/health/ready/`` (readiness)
+    Actually exercises the dependencies a page render needs, and is what the load
+    balancer should target.
+
+Why readiness exists at all: a deployment once returned 500 on every page while
+the load balancer reported the task perfectly healthy, because the health check
+only probed a static endpoint. The task passed, traffic was shifted onto it, and
+the deployment circuit breaker had no reason to intervene. A check that does not
+touch what the application actually needs cannot detect that the application is
+broken.
+"""
+
+import logging
+
+from django.db import connection
+from django.http import JsonResponse
+
+logger = logging.getLogger(__name__)
+
+
+def liveness(request):
+    """Is the process up? Nothing more."""
+    return JsonResponse({'status': 'ok'})
+
+
+def readiness(request):
+    """Can this instance actually serve a page?
+
+    Checks, in order of how often each has broken in practice:
+
+    1. the database answers a query,
+    2. the encrypted constance settings can be read, which is the check that would
+       have caught the SECRET_KEY rotation outage, and
+    3. the built frontend bundle is present, since a missing manifest renders a
+       blank page while every endpoint still returns 200.
+
+    Returns 503 with a per-check breakdown when anything fails, so the load
+    balancer takes the instance out of service instead of serving errors.
+    """
+    checks = {}
+
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute('SELECT 1')
+            cursor.fetchone()
+        checks['database'] = 'ok'
+    except Exception as error:
+        checks['database'] = f'error: {type(error).__name__}'
+
+    try:
+        # Reading these decrypts values whose key derives from SECRET_KEY. The
+        # backend degrades to defaults rather than raising, so assert we got a
+        # usable value instead of merely that no exception escaped.
+        from constance import config
+        if config.YOMA_BASE_URI:
+            checks['settings'] = 'ok'
+        else:
+            checks['settings'] = 'error: constance value empty'
+    except Exception as error:
+        checks['settings'] = f'error: {type(error).__name__}'
+
+    try:
+        from django.template.loader import render_to_string
+        render_to_string('react_base.html', {
+            'dev_mode': False,
+            'GOOGLE_ANALYTICS_TRACKING_CODE': '',
+            'PRIVACY_POLICY_VERSION': None,
+            'COUNTRIES_DICT': '[]',
+            'YOMA_AUTH_URL': '',
+        })
+        checks['frontend'] = 'ok'
+    except Exception as error:
+        checks['frontend'] = f'error: {type(error).__name__}'
+
+    healthy = all(value == 'ok' for value in checks.values())
+    if not healthy:
+        logger.error('Readiness check failed: %s', checks)
+
+    return JsonResponse(
+        {'status': 'ok' if healthy else 'unhealthy', 'checks': checks},
+        status=200 if healthy else 503,
+    )

--- a/django_project/minisass/templates/404.html
+++ b/django_project/minisass/templates/404.html
@@ -1,7 +1,39 @@
-{% extends "base.html" %}
+{% comment %}
+Deliberately self-contained.
 
-{% block "minisass_page_content" %}
-    <div class="minisass-page-content">
-        The resource you were looking for could not be found. Please try again.
+This template previously did {% extends "base.html" %}. No project template of that
+name exists, so it resolved to pinax/templates/templates/base.html, which uses a
+{% user_display %} tag that is not loaded here. Rendering therefore raised
+TemplateSyntaxError, and Django returned 500 instead of 404 for EVERY missing URL,
+including /favicon.ico and /robots.txt.
+
+Keep this page free of {% extends %}, custom tags and external assets so it can
+always render, even when the rest of the application cannot.
+{% endcomment %}<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Page not found | miniSASS</title>
+    <link rel="icon" href="/static/favicon.ico" sizes="any">
+    <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png">
+    <link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
+    <style>
+      body { margin: 0; font-family: -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+             color: #1f2933; background: #f7f9fa; }
+      .wrap { max-width: 640px; margin: 0 auto; padding: 64px 24px; text-align: center; }
+      h1 { font-size: 22px; margin: 0 0 12px; }
+      p { line-height: 1.6; color: #52606d; margin: 0 0 24px; }
+      .btn { display: inline-block; padding: 10px 20px; border-radius: 6px;
+             background: #539987; color: #fff; text-decoration: none; font-weight: 600; }
+      .btn:hover { background: #47836f; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>We could not find that page</h1>
+      <p>The page you were looking for does not exist, or may have moved.</p>
+      <a class="btn" href="/">Back to miniSASS</a>
     </div>
-{% endblock %}
+  </body>
+</html>

--- a/django_project/minisass/templates/500.html
+++ b/django_project/minisass/templates/500.html
@@ -1,58 +1,42 @@
-<!doctype html>
-<html>
+{% comment %}
+Deliberately self-contained: no {% extends %}, no custom template tags and no
+external assets. A 500 page must render when the application is already failing,
+so it cannot depend on anything that might itself be broken. The previous version
+pulled in jQuery from a CDN and several stylesheets, none of which are needed to
+say "something went wrong".
+{% endcomment %}<!doctype html>
+<html lang="en">
   <head>
-    <link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Coming+Soon">
-    <link href="/static/css/normalize.css" media="screen, print" rel="stylesheet">
-    <link href="/static/css/minisass-menu.css" media="screen, print" rel="stylesheet">
-    <link href="/static/css/base.css" media="screen, print" rel="stylesheet">
-
-    <script src="https://code.jquery.com/jquery-1.7.2.min.js"></script>
-    <script src="/static/js/jqueryslidemenu.js"></script>
-
-    <title>
-     miniSASS Error
-    </title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Something went wrong | miniSASS</title>
+    <link rel="icon" href="/static/favicon.ico" sizes="any">
+    <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png">
+    <link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
+    <style>
+      body { margin: 0; font-family: -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+             color: #1f2933; background: #f7f9fa; }
+      .wrap { max-width: 640px; margin: 0 auto; padding: 64px 24px; text-align: center; }
+      h1 { font-size: 22px; margin: 0 0 12px; }
+      p { line-height: 1.6; color: #52606d; margin: 0 0 24px; }
+      .btn { display: inline-block; padding: 10px 20px; border-radius: 6px;
+             background: #539987; color: #fff; text-decoration: none; font-weight: 600; }
+      .btn:hover { background: #47836f; }
+      .muted { font-size: 13px; color: #7b8794; }
+    </style>
   </head>
   <body>
-    <div class="minisass-box"><div class="minisass-container">
-
-      <div class="minisass-heading">
-        <a href="/">
-          <img src="/static/images/mini_SASS_logo.png" alt="miniSASS Logo"
-          title="miniSASS Logo" style="margin: 4px 0 4px 4px">
-        </a>
-        <div class="registration_links">
-        </div>
-        <div class="minisass-heading-space">
-        </div>
-        <div id="myslidemenu">
-          <ul class="minisass-menus">
-          </ul>
-        </div>
-
-      <div class="red-line">
-      </div>
-
-      <div class="minisass-page">
-
-              <div class="minisass-page-content">
-                An error occurred. Please contact simon@groundtruth.co.za for
-                assistance.
-              </div>
-
-              <div class="minisass-right-column">
-              </div>
-
-      </div>
-
-      <div class="minisass-bottom">
-          <div>
-          </div>
-      </div>
-      <div class="minisass-bottom-logos">
-      </div>
-
-    </div></div>
-
+    <div class="wrap">
+      <h1>Something went wrong on our side</h1>
+      <p>
+        This is not your fault. The problem has been logged and the team has been
+        notified. Please try again in a few minutes.
+      </p>
+      <a class="btn" href="/">Back to miniSASS</a>
+      <p class="muted" style="margin-top:28px">
+        If it keeps happening, contact
+        <a href="mailto:info@minisass.org">info@minisass.org</a>.
+      </p>
+    </div>
   </body>
 </html>

--- a/django_project/minisass/tests/test_resilience.py
+++ b/django_project/minisass/tests/test_resilience.py
@@ -11,16 +11,84 @@ These tests pin both halves of the fix: pages must survive a decryption failure,
 and the readiness endpoint must actually notice when the application cannot serve.
 """
 
+import json
+import os
+import shutil
 from unittest.mock import patch
 
 from cryptography.fernet import InvalidToken
+from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 
 from constance.backends.database import DatabaseBackend
 
 
-class ConstanceDecryptionFailureTest(TestCase):
+def ensure_vite_manifest():
+    """
+    Let the SPA shell render whether or not the frontend has been built.
+
+    render_vite_bundle reads src/dist/.vite/manifest.json, which npm run build
+    produces. The Dockerfile does build it, but docker-compose.yml bind-mounts
+    ./django_project over /home/web/django_project and hides it, and dist/ is not
+    tracked in git. On a fresh checkout the file is therefore simply absent, the
+    tag raises FileNotFoundError, and every test that renders a page fails for a
+    reason that has nothing to do with what it is testing.
+
+    A developer rarely sees this because a local checkout usually has a dist/
+    left over from an earlier build. CI never does, which is why these tests
+    passed locally and failed there.
+
+    Writing a stub keeps the test honest about its subject: these tests are about
+    constance decryption and readiness reporting, not about the asset pipeline. A
+    real manifest, when one exists, is always preferred and left untouched.
+
+    Returns a callable that removes whatever was created.
+    """
+    dist = os.path.join(settings.FRONTEND_PATH, 'src', 'dist')
+    vite_dir = os.path.join(dist, '.vite')
+    manifest = os.path.join(vite_dir, 'manifest.json')
+    # The tag falls back to this older location, so a build in either layout counts.
+    legacy_manifest = os.path.join(dist, 'manifest.json')
+
+    if os.path.exists(manifest) or os.path.exists(legacy_manifest):
+        return lambda: None
+
+    dist_created = not os.path.isdir(dist)
+    os.makedirs(vite_dir, exist_ok=True)
+    with open(manifest, 'w') as fd:
+        json.dump(
+            {
+                'index.html': {
+                    'file': 'assets/test-stub.js',
+                    'css': ['assets/test-stub.css'],
+                    'dynamicImports': [],
+                }
+            },
+            fd,
+        )
+
+    def cleanup():
+        shutil.rmtree(dist if dist_created else vite_dir, ignore_errors=True)
+
+    return cleanup
+
+
+class RendersSpaShellMixin:
+    """For tests that render a page through react_base.html."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._vite_manifest_cleanup = ensure_vite_manifest()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._vite_manifest_cleanup()
+        super().tearDownClass()
+
+
+class ConstanceDecryptionFailureTest(RendersSpaShellMixin, TestCase):
     """A value encrypted under a different SECRET_KEY must not break the site."""
 
     def test_home_page_still_renders(self):
@@ -51,7 +119,7 @@ class ConstanceDecryptionFailureTest(TestCase):
             django_settings.CONSTANCE_CONFIG['YOMA_BASE_URI'][0])
 
 
-class HealthEndpointTest(TestCase):
+class HealthEndpointTest(RendersSpaShellMixin, TestCase):
     """Liveness answers "is the process up"; readiness answers "can it serve"."""
 
     def test_liveness_is_cheap_and_always_ok(self):

--- a/django_project/minisass/tests/test_resilience.py
+++ b/django_project/minisass/tests/test_resilience.py
@@ -1,0 +1,76 @@
+# coding=utf-8
+"""Regression tests for the outage caused by rotating SECRET_KEY.
+
+Constance values are encrypted with a key derived from settings.SECRET_KEY.
+Changing the key made every stored value undecryptable, and because
+ReactBaseView reads three of them on every render, the whole site returned 500.
+The load balancer health check probed a static endpoint and kept passing, so
+nothing detected it.
+
+These tests pin both halves of the fix: pages must survive a decryption failure,
+and the readiness endpoint must actually notice when the application cannot serve.
+"""
+
+from unittest.mock import patch
+
+from cryptography.fernet import InvalidToken
+from django.test import TestCase
+from django.urls import reverse
+
+from constance.backends.database import DatabaseBackend
+
+
+class ConstanceDecryptionFailureTest(TestCase):
+    """A value encrypted under a different SECRET_KEY must not break the site."""
+
+    def test_home_page_still_renders(self):
+        with patch.object(DatabaseBackend, 'get', side_effect=InvalidToken):
+            response = self.client.get(reverse('home'))
+        self.assertEqual(
+            response.status_code, 200,
+            'the home page must render even when constance cannot be decrypted')
+
+    def test_map_page_still_renders(self):
+        """ReactBaseView serves several routes; all read the same values."""
+        with patch.object(DatabaseBackend, 'get', side_effect=InvalidToken):
+            response = self.client.get(reverse('map'))
+        self.assertEqual(response.status_code, 200)
+
+    def test_backend_falls_back_to_the_configured_default(self):
+        from django.conf import settings as django_settings
+        from minisass.constance.backend import EncryptedDatabaseBackend
+
+        with patch.object(DatabaseBackend, 'get', side_effect=InvalidToken):
+            value = EncryptedDatabaseBackend.get(
+                EncryptedDatabaseBackend.__new__(EncryptedDatabaseBackend),
+                'YOMA_BASE_URI')
+        self.assertIsNone(
+            value, 'returning None is what makes constance use the default')
+        # And the declared default is a usable value rather than empty.
+        self.assertTrue(
+            django_settings.CONSTANCE_CONFIG['YOMA_BASE_URI'][0])
+
+
+class HealthEndpointTest(TestCase):
+    """Liveness answers "is the process up"; readiness answers "can it serve"."""
+
+    def test_liveness_is_cheap_and_always_ok(self):
+        response = self.client.get(reverse('health'))
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['status'], 'ok')
+
+    def test_readiness_reports_each_dependency(self):
+        response = self.client.get(reverse('health-ready'))
+        self.assertEqual(response.status_code, 200)
+        body = response.json()
+        self.assertEqual(body['status'], 'ok')
+        for dependency in ('database', 'settings', 'frontend'):
+            self.assertEqual(body['checks'][dependency], 'ok', dependency)
+
+    def test_readiness_returns_503_when_the_database_is_unreachable(self):
+        """The check that a static health endpoint could never make."""
+        with patch('django.db.connection.cursor', side_effect=Exception('boom')):
+            response = self.client.get(reverse('health-ready'))
+        self.assertEqual(response.status_code, 503)
+        self.assertEqual(response.json()['status'], 'unhealthy')
+        self.assertIn('error', response.json()['checks']['database'])

--- a/django_project/minisass/tests/test_resilience.py
+++ b/django_project/minisass/tests/test_resilience.py
@@ -74,3 +74,38 @@ class HealthEndpointTest(TestCase):
         self.assertEqual(response.status_code, 503)
         self.assertEqual(response.json()['status'], 'unhealthy')
         self.assertIn('error', response.json()['checks']['database'])
+
+
+class ErrorPageTest(TestCase):
+    """A missing URL must return 404, not 500.
+
+    404.html previously did {% extends "base.html" %}. No project template of that
+    name exists, so it resolved to pinax/templates/templates/base.html, which uses
+    a {% user_display %} tag that is not loaded. Rendering raised
+    TemplateSyntaxError and Django returned 500 for EVERY missing URL, including
+    /favicon.ico and /robots.txt.
+    """
+
+    def test_missing_url_returns_404_not_500(self):
+        with self.settings(DEBUG=False, ALLOWED_HOSTS=['*']):
+            response = self.client.get('/definitely-not-a-real-url-9876')
+        self.assertEqual(
+            response.status_code, 404,
+            'a missing URL must 404; a 500 here means the 404 template is broken')
+
+    def test_404_template_renders_standalone(self):
+        """It must not depend on {% extends %} or a third-party base template."""
+        from django.template.loader import render_to_string
+        html = render_to_string('404.html')
+        self.assertIn('miniSASS', html)
+
+    def test_500_template_renders_standalone(self):
+        from django.template.loader import render_to_string
+        html = render_to_string('500.html')
+        self.assertIn('miniSASS', html)
+
+    def test_favicon_is_routed(self):
+        """Browsers request /favicon.ico at the root regardless of link tags."""
+        response = self.client.get('/favicon.ico')
+        self.assertIn(response.status_code, (301, 302))
+        self.assertIn('favicon', response['Location'])

--- a/django_project/minisass/urls.py
+++ b/django_project/minisass/urls.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.http import HttpResponse
+from minisass.health import liveness, readiness
 from django.urls import path, re_path, include
 from django.conf import settings
 from django.views.static import serve
@@ -89,7 +90,10 @@ urlpatterns = [
     path('swagger<format>/', schema_view.without_ui(cache_timeout=0), name='schema-json'),
     path('swagger/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
-    path("health/", lambda request: HttpResponse("OK"), name="health"),
+    # Liveness: is the process up. Readiness: can it actually serve a page.
+    # The load balancer should target readiness; see minisass/health.py.
+    path("health/", liveness, name="health"),
+    path("health/ready/", readiness, name="health-ready"),
 ]
 
 if settings.DEBUG:

--- a/django_project/minisass/urls.py
+++ b/django_project/minisass/urls.py
@@ -1,5 +1,7 @@
 from django.contrib import admin
 from django.http import HttpResponse
+from django.views.generic.base import RedirectView
+
 from minisass.health import liveness, readiness
 from django.urls import path, re_path, include
 from django.conf import settings
@@ -92,6 +94,10 @@ urlpatterns = [
     path('redoc/', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
     # Liveness: is the process up. Readiness: can it actually serve a page.
     # The load balancer should target readiness; see minisass/health.py.
+    # Browsers request /favicon.ico at the root regardless of any <link> tag,
+    # and nothing routed it, so it fell through to the 404 handler.
+    path("favicon.ico", RedirectView.as_view(
+        url="/static/favicon.ico", permanent=True), name="favicon"),
     path("health/", liveness, name="health"),
     path("health/ready/", readiness, name="health-ready"),
 ]

--- a/django_project/minisass_frontend/templates/react_base.html
+++ b/django_project/minisass_frontend/templates/react_base.html
@@ -14,6 +14,15 @@
   <meta name="referrer" content="origin" />
 <title class="notranslate" translate="no">miniSASS</title>
 
+  <!-- Declared explicitly so browsers use these rather than falling back to a
+       bare request for /favicon.ico at the site root, which Django does not
+       route. The files are collected to STATIC_ROOT by collectstatic. -->
+  <link rel="icon" href="/static/favicon.ico" sizes="any">
+  <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png">
+  <link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png">
+  <link rel="manifest" href="/static/site.webmanifest">
+
   {% if dev_mode %}
   <script type="module" src="http://localhost:5173/@vite/client"></script>
 


### PR DESCRIPTION
Follow-up to #1295, which is already merged and deployed as task definition revision 60. These two commits were pushed after that merge and so never landed.

Both fix problems that surfaced during last night's deploy.

## Every missing URL currently returns 500

Live on production right now:

```
https://minisass.org/nonexistent-abc   ->  HTTP 500
```

`404.html` did `{% extends "base.html" %}`. No project template of that name exists, so it resolved to `pinax/templates/templates/base.html`, which uses a `{% user_display %}` tag that is not loaded. Rendering raised `TemplateSyntaxError`, so Django returned 500 instead of 404 for every missing URL, including `/favicon.ico` and `/robots.txt`.

Both error templates are now self-contained: no `{% extends %}`, no custom tags, no external assets. A page shown while the application is failing must not depend on anything that might also be failing. Favicons are declared explicitly and `/favicon.ico` is routed at the root, since browsers request it regardless of any link tag.

## Static files never reached S3

nginx serves `/static/` by proxying to the S3 bucket, but `collectstatic` writes to the container's local filesystem, which nginx never reads in production. Nothing connected the two, so every object under `static/` dated from the day someone uploaded them by hand.

Revision 60 rebuilt the frontend, producing new content-hashed bundle names that did not exist in S3. Every asset returned 403 and the site rendered blank while still returning 200. It was restored by syncing the files manually.

`deploy.yml` now runs `collectstatic` inside the image it is about to deploy and syncs the result to S3 before updating the service. Running it inside that image means the uploaded files match the deployed code exactly, rather than relying on a separate build producing identical hashes. The sync runs without `--delete` so browsers holding cached HTML can still fetch the bundles it references.

The IAM policy this needs is already applied: the deploy role can write under `static/` only, and is not granted `s3:DeleteObject`, so a deploy can never remove media.

## A SECRET_KEY mismatch no longer takes the site down

Constance values are encrypted with a key derived from `SECRET_KEY`, and `ReactBaseView` reads three of them on every render. Rotating the key made them undecryptable and returned 500 for every page.

A value that cannot be decrypted is now treated as unset and logged loudly, so constance falls back to its configured default and the site keeps serving with the feature degraded. `/health/ready/` is added, exercising the database, the encrypted settings and the frontend template, returning 503 with a per-check breakdown. The old check was a bare `HttpResponse("OK")` that passed happily while every real page was broken, which is why nothing detected the outage.

## Verification

145 tests pass. New tests assert that pages render when decryption fails, that readiness returns 503 when a dependency is unreachable, that a missing URL returns 404, and that both error templates render standalone.

## After merging

Watch this deploy rather than firing and forgetting: it is the first run of the static-publishing step. Afterwards, check `/` in a browser and try a nonsense URL to confirm the 404 works.

The ALB health check can only be pointed at `/health/ready/` once a revision containing it is live.
